### PR TITLE
fix(migrate): remove version details from cvc creation

### DIFF
--- a/cmd/migrate/executor/cstor_volume.go
+++ b/cmd/migrate/executor/cstor_volume.go
@@ -77,7 +77,7 @@ func (m *MigrateOptions) RunCStorVolumeMigrate() error {
 		klog.Error(err)
 		return errors.Errorf("Failed to migrate cStor Volume : %s", m.pvName)
 	}
-	klog.Infof("Successfully migrated volume %s", m.pvName)
+	klog.Infof("Successfully migrated volume %s, scale up the application to verify the migration", m.pvName)
 
 	return nil
 }

--- a/pkg/migrate/cstor/volume.go
+++ b/pkg/migrate/cstor/volume.go
@@ -478,14 +478,6 @@ func (v *VolumeMigrator) createCVC(pvName string) error {
 		}
 		cvcObj.Spec.Provision.ReplicaCount = cvObj.Spec.ReplicationFactor
 		cvcObj.Status.Phase = cstor.CStorVolumeConfigPhasePending
-		cvcObj.VersionDetails = cstor.VersionDetails{
-			Desired:     version.Current(),
-			AutoUpgrade: false,
-			Status: cstor.VersionStatus{
-				Current:            version.Current(),
-				DependentsUpgraded: true,
-			},
-		}
 		if len(cvObj.Labels["openebs.io/source-volume"]) != 0 {
 			cvcObj.Spec.CStorVolumeSource = cvObj.Labels["openebs.io/source-volume"] + "@" + cvObj.Annotations["openebs.io/snapshot"]
 		}


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR fixes the issue of version mismatch between CVC and its controller. As the CVC controller now handles the version population ref: https://github.com/openebs/cstor-operators/pull/106, removing the version details while creating CVC.
This PR also handles the case when podAffinity is set on the application: the affinity is removed as first to validate the volume health and once the volume becomes healthy the podAffinity is patched to the target deployment.