### PR TITLE
refact(upgrade): add labels and annotation for cstor volume

### DIFF
--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	validCurrentVersions = map[string]bool{
-		"1.9.0": true, "1.10.0": true, "1.11.0": true,
+		"1.9.0": true, "1.10.0": true, "1.11.0": true, "1.12.0": true,
 	}
 	validDesiredVersion = GetVersion()
 )


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR  handles upgrade for cstor volumes by adding PVC annotation to CVC and PVC label to CV and target deployment with reference to PRs : https://github.com/openebs/cstor-csi/pull/100 https://github.com/openebs/cstor-operators/pull/124 
This PR also enables RC upgrades for v1.12.0.
Note: PR contains some repetitive code to avoid dependencies between methods that can change in future upgrades.

Local test results:
before upgrade:
```sh
mayadata:upgrade$ k get cvc -oyaml
apiVersion: v1
items:
- apiVersion: cstor.openebs.io/v1
  kind: CStorVolumeConfig
  metadata:
    annotations:
      openebs.io/volume-policy: ""
      openebs.io/volumeID: pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b
.........
mayadata:setup$ k get pod pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b-target-7fd8b98c6f5m4tk --show-labels 
NAME                                                              READY   STATUS    RESTARTS   AGE     LABELS
pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b-target-7fd8b98c6f5m4tk   3/3     Running   0          3m17s   app=cstor-volume-manager,monitoring=volume_exporter_prometheus,openebs.io/persistent-volume=pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b,openebs.io/target=cstor-target,openebs.io/version=1.11.0,pod-template-hash=7fd8b98c6f
mayadata:setup$ k get deploy pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b-target --show-labels 
NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE     LABELS
pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b-target   1/1     1            1           3m30s   app=cstor-volume-manager,openebs.io/cas-type=cstor,openebs.io/persistent-volume=pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b,openebs.io/storage-engine-type=cstor,openebs.io/target=cstor-target,openebs.io/version=1.11.0
```

after upgrade:
```sh
mayadata:upgrade$ k get cvc -oyaml
apiVersion: v1
items:
- apiVersion: cstor.openebs.io/v1
  kind: CStorVolumeConfig
  metadata:
    annotations:
      openebs.io/persistent-volume-claim: demo-csi-vol-claim
      openebs.io/volume-policy: ""
      openebs.io/volumeID: pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b
.........
mayadata:setup$ k get pod pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b-target-6778dccff9d6b9h --show-labels 
NAME                                                              READY   STATUS    RESTARTS   AGE   LABELS
pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b-target-6778dccff9d6b9h   3/3     Running   0          14m   app=cstor-volume-manager,monitoring=volume_exporter_prometheus,openebs.io/persistent-volume-claim=demo-csi-vol-claim,openebs.io/persistent-volume=pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b,openebs.io/target=cstor-target,openebs.io/version=1.12.0-RC1,pod-template-hash=6778dccff9
mayadata:setup$ k get deploy pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b-target --show-labels 
NAME                                              READY   UP-TO-DATE   AVAILABLE   AGE   LABELS
pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b-target   1/1     1            1           24m   app=cstor-volume-manager,openebs.io/cas-type=cstor,openebs.io/persistent-volume-claim=demo-csi-vol-claim,openebs.io/persistent-volume=pvc-4b714a75-61d9-4ec0-93a5-7cb021511c1b,openebs.io/storage-engine-type=cstor,openebs.io/target=cstor-target,openebs.io/version=1.12.0-RC1
```
