### PR TITLE
fix(travis): make upgrade sanity test configurable for different IMAGE_ORG

### DIFF
--- a/ci/upgrade/cstor-operator.tmp.yaml
+++ b/ci/upgrade/cstor-operator.tmp.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
       - name: cspc-operator
         imagePullPolicy: IfNotPresent
-        image: openebs/cspc-operator-amd64:testimage
+        image: imageorg/cspc-operator-amd64:testimage
         env:
         - name: OPENEBS_NAMESPACE
           valueFrom:
@@ -53,11 +53,11 @@ spec:
         #- name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
         #  value: "/var/openebs/sparse"
         - name: OPENEBS_IO_CSPI_MGMT_IMAGE
-          value: "openebs/cstor-pool-manager-amd64:testimage"
+          value: "imageorg/cstor-pool-manager-amd64:testimage"
         - name: OPENEBS_IO_CSTOR_POOL_IMAGE
-          value: "openebs/cstor-pool:testimage"
+          value: "imageorg/cstor-pool:testimage"
         - name:  OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
-          value: "openebs/m-exporter:testimage"
+          value: "imageorg/m-exporter:testimage"
         - name: RESYNC_INTERVAL
           value: "30"
 ---
@@ -89,7 +89,7 @@ spec:
       containers:
       - name: cvc-operator
         imagePullPolicy: IfNotPresent
-        image: openebs/cvc-operator-amd64:testimage
+        image: imageorg/cvc-operator-amd64:testimage
         env:
         # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
         # Where OpenEBS can store required files. Default base path will be /var/openebs
@@ -109,11 +109,11 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
-          value: "openebs/cstor-istgt:testimage"
+          value: "imageorg/cstor-istgt:testimage"
         - name:  OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
-          value: "openebs/cstor-volume-manager-amd64:testimage"
+          value: "imageorg/cstor-volume-manager-amd64:testimage"
         - name:  OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "openebs/m-exporter:testimage"
+          value: "imageorg/m-exporter:testimage"
 ---
 apiVersion: v1
 kind: Service
@@ -159,7 +159,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: admission-webhook
-          image: openebs/cstor-webhook-amd64:testimage
+          image: imageorg/cstor-webhook-amd64:testimage
           imagePullPolicy: IfNotPresent
           args:
             - -alsologtostderr

--- a/ci/upgrade/pool.tmp.yaml
+++ b/ci/upgrade/pool.tmp.yaml
@@ -36,7 +36,7 @@ spec:
         # if required the image prefix of the pool deployments can be
         # changed using the flag below, defaults to whatever was present on old
         # deployments.
-        #- "--to-version-image-prefix=openebs/"
+        - "--to-version-image-prefix=imageorg/"
         # if required the image tags for pool deployments can be changed
         # to a custom image tag using the flag below, 
         # defaults to the --to-version mentioned above.
@@ -58,7 +58,7 @@ spec:
 
         # the image version should be same as the --to-version mentioned above
         # in the args of the job
-        image: openebs/upgrade-amd64:ci
+        image: imageorg/upgrade-amd64:ci
         imagePullPolicy: IfNotPresent
       restartPolicy: OnFailure
 ---

--- a/ci/upgrade/sanity.sh
+++ b/ci/upgrade/sanity.sh
@@ -2,8 +2,17 @@
 
 #!/usr/bin/env bash
 
+set -ex
+
 # To enable dev upgardes in travis
 make upgrade-image.amd64
+
+# To test the sanity in different customized
+# image prefixes
+if [[ ${IMAGE_ORG} == "" ]]; then
+  IMAGE_ORG="openebs";
+  export IMAGE_ORG;
+fi
 
 # To test the sanity in different versioned branches 
 # and travis tags, get the travis version and corresponding
@@ -34,6 +43,8 @@ fi
 
 export TEST_IMAGE_TAG=${TEST_IMAGE_TAG#v}
 export TEST_VERSION=${TEST_VERSION#v}
+
+echo "Testing upgrade for org: $IMAGE_ORG version: $TEST_VERSION imagetag: $TEST_IMAGE_TAG"
 
 # setup openebs & cstor v1 for migration 
 ./ci/upgrade/setup.sh || exit 1

--- a/ci/upgrade/setup.sh
+++ b/ci/upgrade/setup.sh
@@ -28,7 +28,7 @@ kubectl wait --for=condition=available --timeout=300s deployment/percona
 
 echo "Upgrade control plane to latest version"
 
-sed "s|testimage|$TEST_IMAGE_TAG|g" ./ci/upgrade/cstor-operator.tmp.yaml | sed "s|testversion|$TEST_VERSION|g" > ./ci/upgrade/cstor-operator.yaml
+sed "s|testimage|$TEST_IMAGE_TAG|g" ./ci/upgrade/cstor-operator.tmp.yaml | sed "s|testversion|$TEST_VERSION|g" | sed "s|imageorg|$IMAGE_ORG|g" > ./ci/upgrade/cstor-operator.yaml
 
 kubectl apply -f https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/csi-operator.yaml \
  -f ./ci/upgrade/cstor-operator.yaml

--- a/ci/upgrade/test.sh
+++ b/ci/upgrade/test.sh
@@ -2,11 +2,9 @@
 
 #!/usr/bin/env bash
 
-set -ex
-
 echo "Upgrading CSPC pool"
 
-sed "s|testimage|$TEST_IMAGE_TAG|g" ./ci/upgrade/pool.tmp.yaml | sed "s|testversion|$TEST_VERSION|g" > ./ci/upgrade/pool.yaml
+sed "s|testimage|$TEST_IMAGE_TAG|g" ./ci/upgrade/pool.tmp.yaml | sed "s|testversion|$TEST_VERSION|g" | sed "s|imageorg|$IMAGE_ORG|g" > ./ci/upgrade/pool.yaml
 kubectl apply -f ./ci/upgrade/pool.yaml
 sleep 5
 kubectl wait --for=condition=complete job/upgrade-pool -n openebs --timeout=550s
@@ -15,7 +13,7 @@ kubectl logs --tail=50 -l job-name=upgrade-pool -n openebs
 echo "Upgrading CSI volume"
 
 pvname=$(kubectl get pvc demo-csi-vol-claim -o jsonpath="{.spec.volumeName}")
-sed "s|PVNAME|$pvname|g" ./ci/upgrade/volume.tmp.yaml | sed "s|testimage|$TEST_IMAGE_TAG|g" | sed "s|testversion|$TEST_VERSION|g" > ./ci/upgrade/volume.yaml
+sed "s|PVNAME|$pvname|g" ./ci/upgrade/volume.tmp.yaml | sed "s|testimage|$TEST_IMAGE_TAG|g" | sed "s|testversion|$TEST_VERSION|g" | sed "s|imageorg|$IMAGE_ORG|g" > ./ci/upgrade/volume.yaml
 kubectl apply -f ./ci/upgrade/volume.yaml
 sleep 5
 kubectl wait --for=condition=complete job/upgrade-volume -n openebs --timeout=550s

--- a/ci/upgrade/volume.tmp.yaml
+++ b/ci/upgrade/volume.tmp.yaml
@@ -36,7 +36,7 @@ spec:
         # if required the image prefix of the volume deployments can be
         # changed using the flag below, defaults to whatever was present on old
         # deployments.
-        #- "--to-version-image-prefix=openebs/"
+        - "--to-version-image-prefix=imageorg/"
         # if required the image tags for volume deployments can be changed
         # to a custom image tag using the flag below, 
         # defaults to the --to-version mentioned above.
@@ -58,7 +58,7 @@ spec:
 
         # the image version should be same as the --to-version mentioned above
         # in the args of the job
-        image: openebs/upgrade-amd64:ci
+        image: imageorg/upgrade-amd64:ci
         imagePullPolicy: IfNotPresent
       restartPolicy: OnFailure
 ---


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR addresses the error caused when images are built with different IMAGE_ORG and the test fails due to missing tags or incompatibility between openebs & other org images