### PR TITLE
chore(upgrade): add valid current versions for 2.1.0 upgrades

### DIFF
--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -23,7 +23,7 @@ import (
 var (
 	validCurrentVersions = map[string]bool{
 		"1.10.0": true, "1.11.0": true, "1.12.0": true,
-		"2.0.0": true,
+		"2.0.0": true, "2.1.0": true,
 	}
 	validDesiredVersion = strings.Split(GetVersion(), "-")[0]
 )


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR adds 2.1.0 to upgrade matrix for upgrading to custom images tags for 2.1.0