### PR TITLE
chore(build): bump travis go build version to 1.14.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: bionic
 language: go
 
 go:
-  - 1.13.x
+  - 1.14.7
 
 env:
   global:


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR bumps travis go build version to 1.14.7 due to some security issues in older go versions.