### PR TITLE
refact(migration): update volume migration to run in parallel

### DIFF
--- a/pkg/migrate/cstor/volume.go
+++ b/pkg/migrate/cstor/volume.go
@@ -609,10 +609,8 @@ func isSCMigrationRequired(v *VolumeMigrator, scName string) (bool, error) {
 		}
 		return false, err
 	}
-	if err == nil {
-		if tmpSC.Annotations["pv-name"] != v.PVName {
-			return false, nil
-		}
+	if tmpSC.Annotations["pv-name"] != v.PVName {
+		return false, nil
 	}
 	return true, nil
 }


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR updates the volume migration code to update the SC by only one job when multiple jobs running in parallel.

Local test performed:
 Tested by launching 3 migration jobs in parallel and the job failure did not occur. Tried the same test 5 times and did not face the issue.