### PR TITLE
fix(travis): update migrate jobs to use correct imageorg images

### DIFF
--- a/ci/migrate/pool.tmp.yaml
+++ b/ci/migrate/pool.tmp.yaml
@@ -46,5 +46,5 @@ spec:
         tty: true
         # the version of the image should be same the 
         # version of cstor-operator installed.
-        image: openebs/migrate-amd64:ci
+        image: imageorg/migrate-amd64:ci
       restartPolicy: Never

--- a/ci/migrate/test.sh
+++ b/ci/migrate/test.sh
@@ -23,6 +23,7 @@ kubectl wait --for=delete pod -l lkey=lvalue --timeout=600s
 
 echo "Migrating pool to cspc"
 
+sed "s|imageorg|$IMAGE_ORG|g" ./ci/migrate/pool.tmp.yaml > ./ci/migrate/pool.yaml
 kubectl apply -f ./ci/migrate/pool.yaml
 sleep 5
 kubectl wait --for=condition=complete job/migrate-pool -n openebs --timeout=550s
@@ -31,7 +32,7 @@ kubectl logs --tail=50 -l job-name=migrate-pool -n openebs
 echo "Migrating extetnal volume to csi volume"
 
 pvname=$(kubectl get pvc testclaim-busybox-0 -o jsonpath="{.spec.volumeName}")
-sed "s/PVNAME/$pvname/" ./ci/migrate/volume.tmp.yaml > ./ci/migrate/volume.yaml
+sed "s|PVNAME|$pvname|g" ./ci/migrate/volume.tmp.yaml | sed "s|imageorg|$IMAGE_ORG|g" > ./ci/migrate/volume.yaml
 kubectl apply -f ./ci/migrate/volume.yaml
 sleep 5
 kubectl wait --for=condition=complete job/migrate-volume -n openebs --timeout=550s

--- a/ci/migrate/volume.tmp.yaml
+++ b/ci/migrate/volume.tmp.yaml
@@ -45,7 +45,7 @@ spec:
         tty: true
         # the version of the image should be same the 
         # version of cstor-operator installed.
-        image: openebs/migrate-amd64:ci
+        image: imageorg/migrate-amd64:ci
       restartPolicy: OnFailure
 ---
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR fixes the issue of travis failures for forked repos where the imageorg of the images don't match with the `openebs`.

**Special notes for your reviewer**:

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated