### PR TITLE
fix(travis): update migrate jobs to use correct imageorg images

### DIFF
--- a/ci/migrate/pool.tmp.yaml
+++ b/ci/migrate/pool.tmp.yaml
@@ -46,5 +46,5 @@ spec:
         tty: true
         # the version of the image should be same the 
         # version of cstor-operator installed.
-        image: openebs/migrate-amd64:ci
+        image: imageorg/migrate-amd64:ci
       restartPolicy: Never

--- a/ci/migrate/sanity.sh
+++ b/ci/migrate/sanity.sh
@@ -16,6 +16,45 @@
 
 make migrate-image.amd64
 
+# To test the sanity in different customized
+# image prefixes
+if [[ ${IMAGE_ORG} == "" ]]; then
+  IMAGE_ORG="openebs";
+  export IMAGE_ORG;
+fi
+
+# To test the sanity in different versioned branches 
+# and travis tags, get the travis version and corresponding
+# image tags
+# Determine the current branch
+CURRENT_BRANCH=""
+if [ -z ${TRAVIS_BRANCH} ];
+then
+  CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+else
+  CURRENT_BRANCH=${TRAVIS_BRANCH}
+fi
+
+TEST_IMAGE_TAG="${CURRENT_BRANCH}-ci"
+if [ ${CURRENT_BRANCH} = "master" ]; then
+  TEST_IMAGE_TAG="ci"
+fi
+TEST_VERSION="${CURRENT_BRANCH}-dev"
+
+if [ -n "$TRAVIS_TAG" ]; then
+    # Trim the `v` from the TRAVIS_TAG if it exists
+    # Example: v1.10.0 maps to 1.10.0
+    # Example: 1.10.0 maps to 1.10.0
+    # Example: v1.10.0-custom maps to 1.10.0-custom
+    TEST_IMAGE_TAG="${TRAVIS_TAG#v}"
+    TEST_VERSION="${TRAVIS_TAG#v}"
+fi
+
+export TEST_IMAGE_TAG=${TEST_IMAGE_TAG#v}
+export TEST_VERSION=${TEST_VERSION#v}
+
+echo "Testing migrate for org: $IMAGE_ORG version: $TEST_VERSION imagetag: $TEST_IMAGE_TAG"
+
 # setup openebs & cstor v1 for migration 
 ./ci/migrate/setup.sh || exit 1
 # run migration tests

--- a/ci/migrate/setup.sh
+++ b/ci/migrate/setup.sh
@@ -41,4 +41,5 @@ echo "Install cstor & csi operators"
 
 kubectl apply -f https://raw.githubusercontent.com/openebs/charts/gh-pages/cstor-operator.yaml
 sleep 5
+
 kubectl wait --for=condition=available --timeout=600s deployment/cspc-operator -n openebs

--- a/ci/migrate/test.sh
+++ b/ci/migrate/test.sh
@@ -23,6 +23,7 @@ kubectl wait --for=delete pod -l lkey=lvalue --timeout=600s
 
 echo "Migrating pool to cspc"
 
+sed "s|imageorg|$IMAGE_ORG|g" ./ci/migrate/pool.tmp.yaml > ./ci/migrate/pool.yaml
 kubectl apply -f ./ci/migrate/pool.yaml
 sleep 5
 kubectl wait --for=condition=complete job/migrate-pool -n openebs --timeout=550s
@@ -31,7 +32,7 @@ kubectl logs --tail=50 -l job-name=migrate-pool -n openebs
 echo "Migrating extetnal volume to csi volume"
 
 pvname=$(kubectl get pvc testclaim-busybox-0 -o jsonpath="{.spec.volumeName}")
-sed "s/PVNAME/$pvname/" ./ci/migrate/volume.tmp.yaml > ./ci/migrate/volume.yaml
+sed "s|PVNAME|$pvname|g" ./ci/migrate/volume.tmp.yaml | sed "s|imageorg|$IMAGE_ORG|g" > ./ci/migrate/volume.yaml
 kubectl apply -f ./ci/migrate/volume.yaml
 sleep 5
 kubectl wait --for=condition=complete job/migrate-volume -n openebs --timeout=550s

--- a/ci/migrate/volume.tmp.yaml
+++ b/ci/migrate/volume.tmp.yaml
@@ -45,7 +45,7 @@ spec:
         tty: true
         # the version of the image should be same the 
         # version of cstor-operator installed.
-        image: openebs/migrate-amd64:ci
+        image: imageorg/migrate-amd64:ci
       restartPolicy: OnFailure
 ---
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR fixes the issue of travis failures for forked repos where the imageorg of the images don't match with the `openebs`.

**Special notes for your reviewer**:

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated