### PR TITLE
feat(migrate): add support for CR status reporting

### DIFF
--- a/ci/migrate/migrationCRD.yaml
+++ b/ci/migrate/migrationCRD.yaml
@@ -1,3 +1,17 @@
+# Copyright © 2020 The OpenEBS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/ci/migrate/migrationCRD.yaml
+++ b/ci/migrate/migrationCRD.yaml
@@ -12,25 +12,128 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  # name must match the spec fields below, and be in the form: <plural>.<group>
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
   name: migrationtasks.openebs.io
 spec:
-  # group name to use for REST API: /apis/<group>/<version>
   group: openebs.io
-  # version name to use for REST API: /apis/<group>/<version>
-  version: v1alpha1
-  # either Namespaced or Cluster
-  scope: Namespaced
   names:
-    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
-    plural: migrationtasks
-    # singular name to be used as an alias on the CLI and for display
-    singular: migrationtask
-    # kind is normally the CamelCased singular type. Your resource manifests use this.
     kind: MigrationTask
-    # shortNames allow shorter string to match your resource on the CLI
+    listKind: MigrationTaskList
+    plural: migrationtasks
     shortNames:
     - mtask
+    singular: migrationtask
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MigrationTask represents an migration task
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec i.e. specifications of the MigrationTask
+            properties:
+              cstorPool:
+                description: MigrateCStorPool contains the details of the cstor pool
+                  to be migrated
+                properties:
+                  rename:
+                    description: If a CSPC with the same name as SPC already exists
+                      then we can rename SPC during migration using Rename
+                    type: string
+                  spcName:
+                    description: SPCName contains the name of the storage pool claim
+                      to be migrated
+                    type: string
+                type: object
+              cstorVolume:
+                description: MigrateCStorVolume contains the details of the cstor
+                  volume to be migrated
+                properties:
+                  pvName:
+                    description: PVName contains the name of the pv associated with
+                      the cstor volume to be migrated
+                    type: string
+                type: object
+            type: object
+          status:
+            description: Status of MigrationTask
+            properties:
+              completedTime:
+                description: CompletedTime of Migrate
+                format: date-time
+                type: string
+              migrationDetailedStatuses:
+                description: MigrationDetailedStatuses contains the list of statuses
+                  of each step
+                items:
+                  description: MigrationDetailedStatuses represents the latest available
+                    observations of a MigrationTask current state.
+                  properties:
+                    lastUpdatedAt:
+                      description: LastUpdatedTime of a MigrateStep
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human-readable message indicating details about
+                        why the migrationStep is in this state
+                      type: string
+                    phase:
+                      description: Phase indicates if the MigrateStep is waiting,
+                        errored or completed.
+                      type: string
+                    reason:
+                      description: Reason is a brief CamelCase string that describes
+                        any failure and is meant for machine parsing and tidy display
+                        in the CLI
+                      type: string
+                    startTime:
+                      description: StartTime of a MigrateStep
+                      format: date-time
+                      type: string
+                    step:
+                      type: string
+                  type: object
+                type: array
+              phase:
+                description: Phase indicates if a migrationTask is started, success
+                  or errored
+                type: string
+              retries:
+                description: Retries is the number of times the job attempted to migration
+                  the resource
+                type: integer
+              startTime:
+                description: StartTime of Migrate
+                format: date-time
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/ci/migrate/migrationCRD.yaml
+++ b/ci/migrate/migrationCRD.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>

--- a/ci/migrate/migrationCRD.yaml
+++ b/ci/migrate/migrationCRD.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: migrationtasks.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: migrationtasks
+    # singular name to be used as an alias on the CLI and for display
+    singular: migrationtask
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: MigrationTask
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - mtask

--- a/ci/migrate/migrationCRD.yaml
+++ b/ci/migrate/migrationCRD.yaml
@@ -80,6 +80,7 @@ spec:
               completedTime:
                 description: CompletedTime of Migrate
                 format: date-time
+                nullable: true
                 type: string
               migrationDetailedStatuses:
                 description: MigrationDetailedStatuses contains the list of statuses
@@ -91,6 +92,7 @@ spec:
                     lastUpdatedAt:
                       description: LastUpdatedTime of a MigrateStep
                       format: date-time
+                      nullable: true
                       type: string
                     message:
                       description: A human-readable message indicating details about
@@ -108,6 +110,7 @@ spec:
                     startTime:
                       description: StartTime of a MigrateStep
                       format: date-time
+                      nullable: true
                       type: string
                     step:
                       type: string
@@ -124,6 +127,7 @@ spec:
               startTime:
                 description: StartTime of Migrate
                 format: date-time
+                nullable: true
                 type: string
             type: object
         required:

--- a/ci/migrate/setup.sh
+++ b/ci/migrate/setup.sh
@@ -39,6 +39,7 @@ kubectl wait --for=condition=Ready pod -l lkey=lvalue --timeout=600s
 
 echo "Install cstor & csi operators"
 
+kubectl apply -f ./ci/migrate/migrationCRD.yaml
 kubectl apply -f https://raw.githubusercontent.com/openebs/charts/gh-pages/cstor-operator.yaml
 sleep 5
 

--- a/cmd/migrate/executor/options.go
+++ b/cmd/migrate/executor/options.go
@@ -29,6 +29,7 @@ type MigrateOptions struct {
 	spcName          string
 	cspcName         string
 	pvName           string
+	resourceKind     string
 }
 
 var (

--- a/cmd/migrate/executor/resource.go
+++ b/cmd/migrate/executor/resource.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"os"
+	"strings"
+
+	"k8s.io/client-go/rest"
+
+	v1Alpha1API "github.com/openebs/api/v2/pkg/apis/openebs.io/v1alpha1"
+	openebsclientset "github.com/openebs/api/v2/pkg/client/clientset/versioned"
+	"github.com/openebs/maya/pkg/util"
+	cmdUtil "github.com/openebs/upgrade/cmd/util"
+	migrate "github.com/openebs/upgrade/pkg/migrate/cstor"
+	errors "github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	resourceMigrateCmdHelpText = `
+This command migrates the resource mentioned in the MigrationTask CR.
+The name of the MigrationTask CR is extracted from the ENV UPGRADE_TASK
+
+Usage: migrate resource
+`
+)
+
+// ResourceOptions stores information required for migrationTask migrate
+type ResourceOptions struct {
+	name string
+}
+
+// NewMigrateResourceJob migrate a resource from migrationTask
+func NewMigrateResourceJob() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "resource",
+		Short:   "Migrate a resource using the details specified in the MigrationTask CR.",
+		Long:    resourceMigrateCmdHelpText,
+		Example: `migrate resource`,
+		Run: func(cmd *cobra.Command, args []string) {
+			client, err := initClient()
+			util.CheckErr(err, util.Fatal)
+			name := args[0]
+			openebsNamespace := cmdUtil.GetOpenEBSNamespace()
+			migrationTaskObj, err := client.OpenebsV1alpha1().
+				MigrationTasks(openebsNamespace).
+				Get(name, metav1.GetOptions{})
+			util.CheckErr(err, util.Fatal)
+			util.CheckErr(options.InitializeFromMigrationTaskResource(migrationTaskObj), util.Fatal)
+			util.CheckErr(options.RunPreFlightChecks(), util.Fatal)
+			err = options.RunResourceMigrate()
+			if err != nil {
+				migrationTaskObj, uerr := client.OpenebsV1alpha1().MigrationTasks(openebsNamespace).
+					Get(name, metav1.GetOptions{})
+				if uerr != nil {
+					util.Fatal(uerr.Error())
+				}
+				backoffLimit, uerr := getBackoffLimit(openebsNamespace)
+				if uerr != nil {
+					util.Fatal(uerr.Error())
+				}
+				migrationTaskObj.Status.Retries = migrationTaskObj.Status.Retries + 1
+				if migrationTaskObj.Status.Retries == backoffLimit {
+					migrationTaskObj.Status.Phase = v1Alpha1API.MigrateError
+					migrationTaskObj.Status.CompletedTime = metav1.Now()
+				}
+				_, uerr = client.OpenebsV1alpha1().MigrationTasks(openebsNamespace).
+					Update(migrationTaskObj)
+				if uerr != nil {
+					util.Fatal(uerr.Error())
+				}
+				util.Fatal(err.Error())
+			} else {
+				migrationTaskObj, uerr := client.OpenebsV1alpha1().MigrationTasks(openebsNamespace).
+					Get(name, metav1.GetOptions{})
+				if uerr != nil {
+					util.Fatal(uerr.Error())
+				}
+				migrationTaskObj.Status.Phase = v1Alpha1API.MigrateSuccess
+				migrationTaskObj.Status.CompletedTime = metav1.Now()
+				_, uerr = client.OpenebsV1alpha1().MigrationTasks(openebsNamespace).
+					Update(migrationTaskObj)
+				if uerr != nil {
+					util.Fatal(uerr.Error())
+				}
+			}
+		},
+	}
+	return cmd
+}
+
+// InitializeFromMigrationTaskResource will populate the MigrateOptions from given MigrationTask
+func (m *MigrateOptions) InitializeFromMigrationTaskResource(
+	migrationTaskObj *v1Alpha1API.MigrationTask) error {
+
+	if len(strings.TrimSpace(m.openebsNamespace)) == 0 {
+		return errors.Errorf("Cannot execute migrate job: namespace is missing")
+	}
+
+	switch {
+	case migrationTaskObj.Spec.MigrateResource.MigrateCStorPool != nil:
+		m.resourceKind = "storagePoolClaim"
+		m.spcName = migrationTaskObj.Spec.MigrateCStorPool.SPCName
+		m.cspcName = migrationTaskObj.Spec.MigrateCStorPool.Rename
+
+	case migrationTaskObj.Spec.MigrateResource.MigrateCStorVolume != nil:
+		m.resourceKind = "cstorVolume"
+		m.pvName = migrationTaskObj.Spec.MigrateCStorVolume.PVName
+	}
+
+	return nil
+}
+
+// RunResourceMigrate migrates the given migrationTask
+func (m *MigrateOptions) RunResourceMigrate() error {
+	migrate.IsMigrationTaskJob = true
+	var err error
+	switch m.resourceKind {
+	case "storagePoolClaim":
+		err = m.RunCStorSPCMigrate()
+	case "cstorVolume":
+		err = m.RunCStorVolumeMigrate()
+	}
+	return err
+}
+
+func initClient() (openebsclientset.Interface, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "error building kubeconfig")
+	}
+	client, err := openebsclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "error building openebs clientset")
+	}
+	return client, nil
+}
+
+func getBackoffLimit(openebsNamespace string) (int, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return 0, errors.Wrap(err, "error building kubeconfig")
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return 0, errors.Wrap(err, "error building openebs clientset")
+	}
+	podName := os.Getenv("POD_NAME")
+	podObj, err := client.CoreV1().Pods(openebsNamespace).
+		Get(podName, metav1.GetOptions{})
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to get backoff limit")
+	}
+	jobObj, err := client.BatchV1().Jobs(openebsNamespace).
+		Get(podObj.OwnerReferences[0].Name, metav1.GetOptions{})
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to get backoff limit")
+	}
+	// if backoffLimit not present it returns the default as 6
+	if jobObj.Spec.BackoffLimit == nil {
+		return 6, nil
+	}
+	backoffLimit := int(*jobObj.Spec.BackoffLimit)
+	return backoffLimit, nil
+}

--- a/cmd/migrate/executor/setup_job.go
+++ b/cmd/migrate/executor/setup_job.go
@@ -38,6 +38,7 @@ func NewJob() *cobra.Command {
 	cmd.AddCommand(
 		NewMigratePoolJob(),
 		NewMigrateCStorVolumeJob(),
+		NewMigrateResourceJob(),
 	)
 
 	cmd.PersistentFlags().StringVarP(&options.openebsNamespace,

--- a/pkg/migrate/cstor/blockdevice_correction.go
+++ b/pkg/migrate/cstor/blockdevice_correction.go
@@ -295,6 +295,9 @@ func (c *CSPCMigrator) updateBDRefsAndlabels(spcObj *apis.StoragePoolClaim, oldB
 	retryBDCStatus:
 		newBDCObj, err = c.OpenebsClientset.OpenebsV1alpha1().
 			BlockDeviceClaims(c.OpenebsNamespace).Get(newBDCObj.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
 		if newBDCObj.Status.Phase != v1alpha1.BlockDeviceClaimStatusDone {
 			klog.Infof("waiting for bd %s to get bound", newBDObj.Name)
 			time.Sleep(2 * time.Second)

--- a/pkg/migrate/cstor/interface.go
+++ b/pkg/migrate/cstor/interface.go
@@ -17,6 +17,10 @@ limitations under the License.
 package migrate
 
 var (
+	// IsMigrationTaskJob is used to determine
+	// whether to report the utask errors. Errors
+	// are reported only when job is triggered by
+	// the resource command.
 	IsMigrationTaskJob = false
 )
 

--- a/pkg/migrate/cstor/interface.go
+++ b/pkg/migrate/cstor/interface.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package migrate
 
+var (
+	IsMigrationTaskJob = false
+)
+
 // Migrator abstracts the migration of a resource
 type Migrator interface {
 	Migrate(name, namespace string) error

--- a/pkg/migrate/cstor/migrationtask.go
+++ b/pkg/migrate/cstor/migrationtask.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrate
+
+import (
+	v1Alpha1API "github.com/openebs/api/v2/pkg/apis/openebs.io/v1alpha1"
+	openebsclientset "github.com/openebs/api/v2/pkg/client/clientset/versioned"
+	"github.com/pkg/errors"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func updateMigrationDetailedStatus(mtaskObj *v1Alpha1API.MigrationTask,
+	mStatusObj v1Alpha1API.MigrationDetailedStatuses,
+	openebsNamespace string, client openebsclientset.Interface,
+) (*v1Alpha1API.MigrationTask, error) {
+	var err error
+	if !isValidStatus(mStatusObj) {
+		return nil, errors.Errorf(
+			"failed to update migratetask status: invalid status %v",
+			mStatusObj,
+		)
+	}
+	mStatusObj.LastUpdatedTime = metav1.Now()
+	if mStatusObj.Phase == v1Alpha1API.StepWaiting {
+		mStatusObj.StartTime = mStatusObj.LastUpdatedTime
+		mtaskObj.Status.MigrationDetailedStatuses = append(
+			mtaskObj.Status.MigrationDetailedStatuses,
+			mStatusObj,
+		)
+	} else {
+		l := len(mtaskObj.Status.MigrationDetailedStatuses)
+		mStatusObj.StartTime = mtaskObj.Status.MigrationDetailedStatuses[l-1].StartTime
+		mtaskObj.Status.MigrationDetailedStatuses[l-1] = mStatusObj
+	}
+	mtaskObj, err = client.OpenebsV1alpha1().
+		MigrationTasks(openebsNamespace).Update(mtaskObj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to update migratetask ")
+	}
+	return mtaskObj, nil
+}
+
+// isValidStatus is used to validate IsValidStatus
+func isValidStatus(o v1Alpha1API.MigrationDetailedStatuses) bool {
+	if o.Step == "" {
+		return false
+	}
+	if o.Phase == "" {
+		return false
+	}
+	if o.Message == "" && o.Phase != v1Alpha1API.StepWaiting {
+		return false
+	}
+	if o.Reason == "" && o.Phase == v1Alpha1API.StepErrored {
+		return false
+	}
+	return true
+}
+
+// getOrCreateMigrationTask fetches migrate task if provided or creates a new migrationtask CR
+func getOrCreateMigrationTask(kind, name, openebsNamespace string, r Migrator,
+	client openebsclientset.Interface) (*v1Alpha1API.MigrationTask, error) {
+	var mtaskObj *v1Alpha1API.MigrationTask
+	var err error
+	mtaskObj = buildMigrationTask(kind, name, r)
+	// the below logic first tries to fetch the CR if not found
+	// then creates a new CR
+	mtaskObj1, err1 := client.OpenebsV1alpha1().
+		MigrationTasks(openebsNamespace).
+		Get(mtaskObj.Name, metav1.GetOptions{})
+	if err1 != nil {
+		if k8serror.IsNotFound(err1) {
+			mtaskObj, err = client.OpenebsV1alpha1().
+				MigrationTasks(openebsNamespace).Create(mtaskObj)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err1
+		}
+	} else {
+		mtaskObj = mtaskObj1
+	}
+
+	if mtaskObj.Status.StartTime.IsZero() {
+		mtaskObj.Status.Phase = v1Alpha1API.MigrateStarted
+		mtaskObj.Status.StartTime = metav1.Now()
+	}
+
+	mtaskObj.Status.MigrationDetailedStatuses = []v1Alpha1API.MigrationDetailedStatuses{}
+	mtaskObj, err = client.OpenebsV1alpha1().
+		MigrationTasks(openebsNamespace).
+		Update(mtaskObj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to update migratetask")
+	}
+	return mtaskObj, nil
+}
+
+func buildMigrationTask(kind, name string, m Migrator) *v1Alpha1API.MigrationTask {
+	// TODO builder
+	mtaskObj := &v1Alpha1API.MigrationTask{
+		ObjectMeta: metav1.ObjectMeta{},
+		Spec:       v1Alpha1API.MigrationTaskSpec{},
+		Status: v1Alpha1API.MigrationTaskStatus{
+			Phase:     v1Alpha1API.MigrateStarted,
+			StartTime: metav1.Now(),
+		},
+	}
+	switch kind {
+	case "cstorPool":
+		r := m.(*CSPCMigrator)
+		mtaskObj.Name = "migrate-cstor-pool-" + name
+		mtaskObj.Spec.MigrateResource = v1Alpha1API.MigrateResource{
+			MigrateCStorPool: &v1Alpha1API.MigrateCStorPool{
+				SPCName: name,
+				Rename:  r.CSPCName,
+			},
+		}
+	case "cstorVolume":
+		r := m.(*VolumeMigrator)
+		mtaskObj.Name = "migrate-cstor-volume-" + name
+		mtaskObj.Spec.MigrateResource = v1Alpha1API.MigrateResource{
+			MigrateCStorVolume: &v1Alpha1API.MigrateCStorVolume{
+				PVName: r.PVName,
+			},
+		}
+	}
+	return mtaskObj
+}

--- a/pkg/migrate/cstor/pool.go
+++ b/pkg/migrate/cstor/pool.go
@@ -224,7 +224,7 @@ func (c *CSPCMigrator) migrate(spcName string) (string, error) {
 	}
 	err = c.updateBDCOwnerRef()
 	if err != nil {
-		msg = "failed to update bdc with cspc ownerref"
+		msg = "failed to update bdc with cspc ownerReference"
 		return msg, err
 	}
 	// List all cspi created with reconcile off

--- a/pkg/migrate/cstor/volume.go
+++ b/pkg/migrate/cstor/volume.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	cstor "github.com/openebs/api/v2/pkg/apis/cstor/v1"
+	v1Alpha1API "github.com/openebs/api/v2/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/api/v2/pkg/apis/types"
 	openebsclientset "github.com/openebs/api/v2/pkg/client/clientset/versioned"
 	apis "github.com/openebs/maya/pkg/apis/openebs.io/v1alpha1"
@@ -79,28 +80,98 @@ func (v *VolumeMigrator) Migrate(pvName, openebsNamespace string) error {
 	if err != nil {
 		return errors.Wrap(err, "error building openebs clientset")
 	}
-	err = v.validateCVCOperator()
+	mtask, err := getOrCreateMigrationTask("cstorVolume", pvName, v.OpenebsNamespace, v, v.OpenebsClientset)
 	if err != nil {
 		return err
 	}
+	statusObj := v1Alpha1API.MigrationDetailedStatuses{Step: "Pre-migration"}
+	statusObj.Phase = v1Alpha1API.StepWaiting
+	mtask, uerr := updateMigrationDetailedStatus(mtask, statusObj, v.OpenebsNamespace, v.OpenebsClientset)
+	if uerr != nil && IsMigrationTaskJob {
+		return uerr
+	}
+	msg, err := v.preMigrate()
+	if err != nil {
+		statusObj.Message = msg
+		statusObj.Reason = err.Error()
+		mtask, uerr = updateMigrationDetailedStatus(mtask, statusObj, v.OpenebsNamespace, v.OpenebsClientset)
+		if uerr != nil && IsMigrationTaskJob {
+			return uerr
+		}
+		return errors.Wrap(err, msg)
+	}
+	statusObj.Phase = v1Alpha1API.StepCompleted
+	statusObj.Message = "Pre-migration steps were successful"
+	statusObj.Reason = ""
+	mtask, uerr = updateMigrationDetailedStatus(mtask, statusObj, v.OpenebsNamespace, v.OpenebsClientset)
+	if uerr != nil && IsMigrationTaskJob {
+		return uerr
+	}
+
+	statusObj = v1Alpha1API.MigrationDetailedStatuses{Step: "Migrate"}
+	statusObj.Phase = v1Alpha1API.StepWaiting
+	mtask, uerr = updateMigrationDetailedStatus(mtask, statusObj, v.OpenebsNamespace, v.OpenebsClientset)
+	if uerr != nil && IsMigrationTaskJob {
+		return uerr
+	}
+	msg, err = v.migrateAll(pvName)
+	if err != nil {
+		statusObj.Message = msg
+		statusObj.Reason = err.Error()
+		mtask, uerr = updateMigrationDetailedStatus(mtask, statusObj, v.OpenebsNamespace, v.OpenebsClientset)
+		if uerr != nil && IsMigrationTaskJob {
+			return uerr
+		}
+		return errors.Wrap(err, msg)
+	}
+	statusObj.Phase = v1Alpha1API.StepCompleted
+	statusObj.Message = "Migration steps were successful"
+	statusObj.Reason = ""
+	mtask, uerr = updateMigrationDetailedStatus(mtask, statusObj, v.OpenebsNamespace, v.OpenebsClientset)
+	if uerr != nil && IsMigrationTaskJob {
+		return uerr
+	}
+	return nil
+}
+
+func (v *VolumeMigrator) migrateAll(pvName string) (string, error) {
+	var msg string
 	shouldMigrate, err := v.isMigrationRequired()
 	if err != nil {
-		return err
+		msg = "failed to check migration status"
+		return msg, err
 	}
 	if shouldMigrate {
-		err = v.migrate()
+		msg, err = v.migrate()
 		if err != nil {
-			return err
+			return msg, err
 		}
 	} else {
 		klog.Infof("Volume %s already migrated to csi spec", pvName)
 	}
 	err = v.deleteTempPolicy()
 	if err != nil {
-		return errors.Wrapf(err, "failed to delete temporary policy %s", pvName)
+		msg = "failed to delete temporary policy " + pvName
+		return msg, err
 	}
 	snap := &SnapshotMigrator{}
-	return snap.migrate(pvName)
+	err = snap.migrate(pvName)
+	if err != nil {
+		msg = "failed migrate snapshots for volume " + pvName
+		return msg, err
+	}
+	return "", nil
+}
+
+func (v *VolumeMigrator) preMigrate() (string, error) {
+	var msg string
+	err := v.validateCVCOperator()
+	if err != nil {
+		msg = "error validating cvc operator"
+		return msg, err
+	}
+	return "", err
+
 }
 
 func (v *VolumeMigrator) isMigrationRequired() (bool, error) {
@@ -159,40 +230,48 @@ func (v *VolumeMigrator) validateCVCOperator() error {
 }
 
 // migrate migrates the volume from non-CSI schema to CSI schema
-func (v *VolumeMigrator) migrate() error {
+func (v *VolumeMigrator) migrate() (string, error) {
+	var msg string
 	var pvObj *corev1.PersistentVolume
 	pvcObj, pvPresent, err := v.validatePVName()
 	if err != nil {
-		return errors.Wrapf(err, "failed to validate pvname")
+		msg = "failed to validate pvname"
+		return msg, err
 	}
 	err = v.populateCVNamespace(v.PVName)
 	if err != nil {
-		return errors.Wrapf(err, "failed to cv namespace")
+		msg = "failed to fetch cv namespace"
+		return msg, err
 	}
 	err = v.createTempPolicy()
 	if err != nil {
-		return errors.Wrapf(err, "failed to create temporary policy")
+		msg = "failed to create temporary policy"
+		return msg, err
 	}
 	if pvPresent {
 		klog.Infof("Checking volume is not mounted on any application")
 		pvObj, err = v.IsVolumeMounted(v.PVName)
 		if err != nil {
-			return errors.Wrapf(err, "failed to verify mount status for pv {%s}", v.PVName)
+			msg = "failed to verify mount status for pv " + v.PVName
+			return msg, err
 		}
 		if pvObj.Spec.PersistentVolumeSource.CSI == nil {
 			klog.Infof("Retaining PV to migrate into csi volume")
 			err = v.RetainPV(pvObj)
 			if err != nil {
-				return errors.Wrapf(err, "failed to retain pv {%s}", v.PVName)
+				msg = "failed to retain pv " + v.PVName
+				return msg, err
 			}
 		}
 		err = v.updateStorageClass(pvObj.Name, pvObj.Spec.StorageClassName)
 		if err != nil {
-			return errors.Wrapf(err, "failed to update storageclass {%s}", pvObj.Spec.StorageClassName)
+			msg = "failed to update storageclass " + pvObj.Spec.StorageClassName
+			return msg, err
 		}
 		pvcObj, err = v.migratePVC(pvObj)
 		if err != nil {
-			return errors.Wrapf(err, "failed to migrate pvc to csi spec")
+			msg = "failed to migrate pvc to csi spec"
+			return msg, err
 		}
 	} else {
 		klog.Infof("PVC and storageclass already migrated to csi format")
@@ -200,34 +279,41 @@ func (v *VolumeMigrator) migrate() error {
 	v.StorageClass, err = v.KubeClientset.StorageV1().
 		StorageClasses().Get(*pvcObj.Spec.StorageClassName, metav1.GetOptions{})
 	if err != nil {
-		return err
+		msg = "failed to get storageclass " + *pvcObj.Spec.StorageClassName
+		return msg, err
 	}
 	pvObj, err = v.migratePV(pvcObj)
 	if err != nil {
-		return errors.Wrapf(err, "failed to migrate pv to csi spec")
+		msg = "failed to migrate pv to csi spec"
+		return msg, err
 	}
 	err = v.removeOldTarget()
 	if err != nil {
-		return errors.Wrapf(err, "failed to remove old target deployment")
+		msg = "failed to remove old target deployment"
+		return msg, err
 	}
 	klog.Infof("Creating CVC to bound the volume and trigger CSI driver")
 	err = v.createCVC(pvObj)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create cvc")
+		msg = "failed to create cvc"
+		return msg, err
 	}
 	err = v.validateMigratedVolume()
 	if err != nil {
-		return errors.Wrapf(err, "failed to validate migrated volume")
+		msg = "failed to validate migrated volume"
+		return msg, err
 	}
 	err = v.patchTargetPodAffinity()
 	if err != nil {
-		return errors.Wrap(err, "failed to patch target affinity")
+		msg = "failed to patch target affinity"
+		return msg, err
 	}
 	err = v.cleanupOldResources()
 	if err != nil {
-		return errors.Wrapf(err, "failed to cleanup old volume resources")
+		msg = "failed to cleanup old volume resources"
+		return msg, err
 	}
-	return nil
+	return "", nil
 }
 
 func (v *VolumeMigrator) migratePVC(pvObj *corev1.PersistentVolume) (*corev1.PersistentVolumeClaim, error) {

--- a/pkg/migrate/cstor/volume.go
+++ b/pkg/migrate/cstor/volume.go
@@ -356,6 +356,9 @@ func (v *VolumeMigrator) addSkipAnnotationToPVC(pvcObj *corev1.PersistentVolumeC
 			k8stypes.StrategicMergePatchType,
 			data,
 		)
+		if err != nil {
+			return err
+		}
 	}
 	return err
 }
@@ -829,6 +832,9 @@ func (v *VolumeMigrator) removeOldTarget() error {
 	// migrate the target service to openebs namespace
 	if v.CVNamespace != v.OpenebsNamespace {
 		err = v.migrateTargetSVC()
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/migrate/cstor/volume.go
+++ b/pkg/migrate/cstor/volume.go
@@ -157,7 +157,7 @@ func (v *VolumeMigrator) migrateAll(pvName string) (string, error) {
 	snap := &SnapshotMigrator{}
 	err = snap.migrate(pvName)
 	if err != nil {
-		msg = "failed migrate snapshots for volume " + pvName
+		msg = "failed to migrate snapshots for volume " + pvName
 		return msg, err
 	}
 	return "", nil


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR adds support for status reports using a CR.

**Which issue(s) this PR fixes**:
Fixes #40 

**Special notes for your reviewer**:
Tested locally with below CRs
Step1: migration CRD
```yaml
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  # name must match the spec fields below, and be in the form: <plural>.<group>
  name: migrationtasks.openebs.io
spec:
  # group name to use for REST API: /apis/<group>/<version>
  group: openebs.io
  # version name to use for REST API: /apis/<group>/<version>
  version: v1alpha1
  # either Namespaced or Cluster
  scope: Namespaced
  names:
    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
    plural: migrationtasks
    # singular name to be used as an alias on the CLI and for display
    singular: migrationtask
    # kind is normally the CamelCased singular type. Your resource manifests use this.
    kind: MigrationTask
    # shortNames allow shorter string to match your resource on the CLI
    shortNames:
    - mtask
```

Step2: created mtasks
```yaml
apiVersion: openebs.io/v1alpha1
kind: MigrationTask
metadata:
  name: migrate-cstor-pool-cstor-pool-1
  namespace: openebs
spec:
  cstorPool:
    spcName: cstor-pool-1
---
apiVersion: openebs.io/v1alpha1
kind: MigrationTask
metadata:
  name: migrate-cstor-volume-pvc-a76b8092-063c-4004-8c3f-f1d2808a064a
  namespace: openebs
spec:
  cstorVolume:
    pvName: pvc-a76b8092-063c-4004-8c3f-f1d2808a064a
```
**Note: the CR names should follow the format as mentioned in the code.**

Step3: Job used for pool (similar for volume just change the mtask name)
```yaml
---
apiVersion: batch/v1
kind: Job
metadata:
  name: migrate-spc-cstor-pool-1
  namespace: openebs
spec:
  backoffLimit: 0
  template:
    spec:
      #VERIFY the value of serviceAccountName is pointing to service account
      # created within openebs namespace. Use the non-default account.
      # by running `kubectl get sa -n <openebs-namespace>`
      serviceAccountName: openebs-maya-operator
      containers:
      - name:  migrate
        args:
        - "resource"
        # name of the mtask for details that is to be migrated
        - "migrate-cstor-pool-cstor-pool-1"
      
        #Following are optional parameters
        #Log Level
        - "--v=4"
        #DO NOT CHANGE BELOW PARAMETERS
        env:
        - name: OPENEBS_NAMESPACE
          valueFrom:
            fieldRef:
              fieldPath: metadata.namespace
        tty: true
        image: openebs/migrate-amd64:ci
        imagePullPolicy: IfNotPresent
      restartPolicy: Never
```

Status reported on the mtask(pool):

```sh
$ k get mtask migrate-cstor-pool-cstor-pool-1 -oyaml -w
apiVersion: openebs.io/v1alpha1
kind: MigrationTask
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"openebs.io/v1alpha1","kind":"MigrationTask","metadata":{"annotations":{},"name":"migrate-cstor-pool-cstor-pool-1","namespace":"openebs"},"spec":{"cstorPool":{"spcName":"cstor-pool-1"}}}
  creationTimestamp: "2020-10-21T16:18:17Z"
  generation: 1
  name: migrate-cstor-pool-cstor-pool-1
  namespace: openebs
  resourceVersion: "7285"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/migrationtasks/migrate-cstor-pool-cstor-pool-1
  uid: b3f0bd88-e7ad-443c-afd8-fd5abc5cea32
spec:
  cstorPool:
    spcName: cstor-pool-1
---
apiVersion: openebs.io/v1alpha1
kind: MigrationTask
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"openebs.io/v1alpha1","kind":"MigrationTask","metadata":{"annotations":{},"name":"migrate-cstor-pool-cstor-pool-1","namespace":"openebs"},"spec":{"cstorPool":{"spcName":"cstor-pool-1"}}}
  creationTimestamp: "2020-10-21T16:18:17Z"
  generation: 2
  name: migrate-cstor-pool-cstor-pool-1
  namespace: openebs
  resourceVersion: "8823"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/migrationtasks/migrate-cstor-pool-cstor-pool-1
  uid: b3f0bd88-e7ad-443c-afd8-fd5abc5cea32
spec:
  cstorPool:
    spcName: cstor-pool-1
status:
  completedTime: null
  phase: Started
  startTime: "2020-10-21T16:30:32Z"
---
apiVersion: openebs.io/v1alpha1
kind: MigrationTask
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"openebs.io/v1alpha1","kind":"MigrationTask","metadata":{"annotations":{},"name":"migrate-cstor-pool-cstor-pool-1","namespace":"openebs"},"spec":{"cstorPool":{"spcName":"cstor-pool-1"}}}
  creationTimestamp: "2020-10-21T16:18:17Z"
  generation: 3
  name: migrate-cstor-pool-cstor-pool-1
  namespace: openebs
  resourceVersion: "8824"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/migrationtasks/migrate-cstor-pool-cstor-pool-1
  uid: b3f0bd88-e7ad-443c-afd8-fd5abc5cea32
spec:
  cstorPool:
    spcName: cstor-pool-1
status:
  completedTime: null
  migrationDetailedStatuses:
  - lastUpdatedAt: "2020-10-21T16:30:32Z"
    phase: Waiting
    startTime: "2020-10-21T16:30:32Z"
    step: Pre-migration
  phase: Started
  startTime: "2020-10-21T16:30:32Z"
---
apiVersion: openebs.io/v1alpha1
kind: MigrationTask
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"openebs.io/v1alpha1","kind":"MigrationTask","metadata":{"annotations":{},"name":"migrate-cstor-pool-cstor-pool-1","namespace":"openebs"},"spec":{"cstorPool":{"spcName":"cstor-pool-1"}}}
  creationTimestamp: "2020-10-21T16:18:17Z"
  generation: 4
  name: migrate-cstor-pool-cstor-pool-1
  namespace: openebs
  resourceVersion: "8827"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/migrationtasks/migrate-cstor-pool-cstor-pool-1
  uid: b3f0bd88-e7ad-443c-afd8-fd5abc5cea32
spec:
  cstorPool:
    spcName: cstor-pool-1
status:
  completedTime: null
  migrationDetailedStatuses:
  - lastUpdatedAt: "2020-10-21T16:30:32Z"
    message: Pre-migration steps were successful
    phase: Completed
    startTime: "2020-10-21T16:30:32Z"
    step: Pre-migration
  phase: Started
  startTime: "2020-10-21T16:30:32Z"
---
apiVersion: openebs.io/v1alpha1
kind: MigrationTask
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"openebs.io/v1alpha1","kind":"MigrationTask","metadata":{"annotations":{},"name":"migrate-cstor-pool-cstor-pool-1","namespace":"openebs"},"spec":{"cstorPool":{"spcName":"cstor-pool-1"}}}
  creationTimestamp: "2020-10-21T16:18:17Z"
  generation: 5
  name: migrate-cstor-pool-cstor-pool-1
  namespace: openebs
  resourceVersion: "8828"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/migrationtasks/migrate-cstor-pool-cstor-pool-1
  uid: b3f0bd88-e7ad-443c-afd8-fd5abc5cea32
spec:
  cstorPool:
    spcName: cstor-pool-1
status:
  completedTime: null
  migrationDetailedStatuses:
  - lastUpdatedAt: "2020-10-21T16:30:32Z"
    message: Pre-migration steps were successful
    phase: Completed
    startTime: "2020-10-21T16:30:32Z"
    step: Pre-migration
  - lastUpdatedAt: "2020-10-21T16:30:32Z"
    phase: Waiting
    startTime: "2020-10-21T16:30:32Z"
    step: Migrate
  phase: Started
  startTime: "2020-10-21T16:30:32Z"
---
apiVersion: openebs.io/v1alpha1
kind: MigrationTask
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"openebs.io/v1alpha1","kind":"MigrationTask","metadata":{"annotations":{},"name":"migrate-cstor-pool-cstor-pool-1","namespace":"openebs"},"spec":{"cstorPool":{"spcName":"cstor-pool-1"}}}
  creationTimestamp: "2020-10-21T16:18:17Z"
  generation: 6
  name: migrate-cstor-pool-cstor-pool-1
  namespace: openebs
  resourceVersion: "9008"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/migrationtasks/migrate-cstor-pool-cstor-pool-1
  uid: b3f0bd88-e7ad-443c-afd8-fd5abc5cea32
spec:
  cstorPool:
    spcName: cstor-pool-1
status:
  completedTime: null
  migrationDetailedStatuses:
  - lastUpdatedAt: "2020-10-21T16:30:32Z"
    message: Pre-migration steps were successful
    phase: Completed
    startTime: "2020-10-21T16:30:32Z"
    step: Pre-migration
  - lastUpdatedAt: "2020-10-21T16:31:29Z"
    message: Migration steps were successful
    phase: Completed
    startTime: "2020-10-21T16:30:32Z"
    step: Migrate
  phase: Started
  startTime: "2020-10-21T16:30:32Z"
---
apiVersion: openebs.io/v1alpha1
kind: MigrationTask
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"openebs.io/v1alpha1","kind":"MigrationTask","metadata":{"annotations":{},"name":"migrate-cstor-pool-cstor-pool-1","namespace":"openebs"},"spec":{"cstorPool":{"spcName":"cstor-pool-1"}}}
  creationTimestamp: "2020-10-21T16:18:17Z"
  generation: 7
  name: migrate-cstor-pool-cstor-pool-1
  namespace: openebs
  resourceVersion: "9010"
  selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/migrationtasks/migrate-cstor-pool-cstor-pool-1
  uid: b3f0bd88-e7ad-443c-afd8-fd5abc5cea32
spec:
  cstorPool:
    spcName: cstor-pool-1
status:
  completedTime: "2020-10-21T16:31:29Z"
  migrationDetailedStatuses:
  - lastUpdatedAt: "2020-10-21T16:30:32Z"
    message: Pre-migration steps were successful
    phase: Completed
    startTime: "2020-10-21T16:30:32Z"
    step: Pre-migration
  - lastUpdatedAt: "2020-10-21T16:31:29Z"
    message: Migration steps were successful
    phase: Completed
    startTime: "2020-10-21T16:30:32Z"
    step: Migrate
  phase: Success
  startTime: "2020-10-21T16:30:32Z"
```
**Also successfully tested the migration without creating mtask using the regular migration jobs.**

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated