### PR TITLE
refact(build): run only amd64 and arm64 builds

### DIFF
--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -25,7 +25,7 @@ endif
 
 # default list of platforms for which multiarch image is built
 ifeq (${PLATFORMS}, )
-	export PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le"
+	export PLATFORMS="linux/amd64,linux/arm64"
 endif
 
 # if IMG_RESULT is unspecified, by default the image will be pushed to registry


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Enabling more than two arch in the multi-arch builds
is resulting in increased build times as well as
intermittent failures in running the builds.

Limiting to two archs - amd64 and arm64 for now.

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated