### PR TITLE
fix(build): propagate RELEASE_TAG to buildx container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,10 +45,13 @@ jobs:
           if [ ${BRANCH} = "master" ]; then
             CI_TAG="ci"
           fi
-          echo "::set-env name=TAG::${CI_TAG}"
-          echo "::set-env name=BRANCH::${BRANCH}"
+          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${CI_TAG}"
+          echo "TAG: ${TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -88,10 +91,13 @@ jobs:
           if [ ${BRANCH} = "master" ]; then
             CI_TAG="ci"
           fi
-          echo "::set-env name=TAG::${CI_TAG}"
-          echo "::set-env name=BRANCH::${BRANCH}"
+          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${CI_TAG}"
+          echo "TAG: ${TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,12 @@ jobs:
       - name: Set Tag
         run: |
           TAG="${GITHUB_REF#refs/*/v}"
-          echo "::set-env name=TAG::${TAG}"
-          echo "::set-env name=RELEASE_TAG::${TAG}"
-          echo "RELEASE_TAG ${TAG}"
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
+          echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -65,9 +68,12 @@ jobs:
       - name: Set Tag
         run: |
           TAG="${GITHUB_REF#refs/*/v}"
-          echo "::set-env name=TAG::${TAG}"
-          echo "::set-env name=RELEASE_TAG::${TAG}"
-          echo "RELEASE_TAG ${TAG}"
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
+          echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ export XC_ARCH
 ARCH:=${XC_OS}_${XC_ARCH}
 export ARCH
 
-export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL}
+export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg RELEASE_TAG=${RELEASE_TAG} --build-arg BRANCH=${BRANCH}
 
 # Specify the name for the binaries
 UPGRADE=upgrade

--- a/build/migrate/migrate.Dockerfile
+++ b/build/migrate/migrate.Dockerfile
@@ -16,6 +16,8 @@
 #
 FROM golang:1.14.7 as build
 
+ARG RELEASE_TAG
+ARG BRANCH
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT=""
@@ -25,7 +27,9 @@ ENV GO111MODULE=on \
   GOARCH=${TARGETARCH} \
   GOARM=${TARGETVARIANT} \
   DEBIAN_FRONTEND=noninteractive \
-  PATH="/root/go/bin:${PATH}"
+  PATH="/root/go/bin:${PATH}" \
+  RELEASE_TAG=${RELEASE_TAG} \
+  BRANCH=${BRANCH}
 
 WORKDIR /go/src/github.com/openebs/upgrade/
 

--- a/build/upgrade/upgrade.Dockerfile
+++ b/build/upgrade/upgrade.Dockerfile
@@ -16,6 +16,8 @@
 #
 FROM golang:1.14.7 as build
 
+ARG RELEASE_TAG
+ARG BRANCH
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT=""
@@ -25,7 +27,9 @@ ENV GO111MODULE=on \
   GOARCH=${TARGETARCH} \
   GOARM=${TARGETVARIANT} \
   DEBIAN_FRONTEND=noninteractive \
-  PATH="/root/go/bin:${PATH}"
+  PATH="/root/go/bin:${PATH}" \
+  RELEASE_TAG=${RELEASE_TAG} \
+  BRANCH=${BRANCH}
 
 WORKDIR /go/src/github.com/openebs/upgrade/
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
The RELEASE_TAG env set in the action is not propagated to the buildx container. This PR fixes the same.
This PR also removes the deprecated envs

**Which issue(s) this PR fixes**:
Fixes #<issue number>


**Special notes for your reviewer**:

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated