### PR TITLE
fix(migrate): update lock file path when csp is scaled down

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -125,6 +125,9 @@ I0520 10:01:25.674512       1 pool.go:395] Updating cvr pvc-9cf5a405-12c0-4522-b
 I0520 10:01:25.798889       1 pool.go:80] Successfully migrated spc sparse-claim to cspc
 ```
 
+**<span style="color: red;">Note: In case the job fails for any reason please do not scale up the old CSP deployments. It can lead to data corruption.</span>**
+
+
 ## cStor External Provisioned volumes to cStor CSI volumes
 
 These instructions will guide you through the process of migrating cStor volumes from the old v1apha1 external provisioned spec to v1 CSI spec. 

--- a/pkg/migrate/cstor/pool.go
+++ b/pkg/migrate/cstor/pool.go
@@ -474,7 +474,7 @@ func getCSP(cspLabel string) (*apis.CStorPool, error) {
 // enabled to avoid importing the pool at two places at the same time.
 func (c *CSPCMigrator) scaleDownDeployment(cspName, cspiName, openebsNamespace string) error {
 	var zero int32 = 0
-	klog.Infof("Scaling down deployment %s", cspName)
+	klog.Infof("Scaling down csp deployment %s", cspName)
 	cspDeployList, err := c.KubeClientset.AppsV1().
 		Deployments(openebsNamespace).List(
 		metav1.ListOptions{
@@ -500,7 +500,7 @@ func (c *CSPCMigrator) scaleDownDeployment(cspName, cspiName, openebsNamespace s
 	newCSPDeploy.Spec.Template.Spec.Volumes = cspiDeploy.Spec.Template.Spec.Volumes
 	patchData, err := GetPatchData(cspDeployList.Items[0], newCSPDeploy)
 	if err != nil {
-		return errors.Wrapf(err, "failed to scale down deployment for csp %s", cspName)
+		return errors.Wrapf(err, "failed to patch data for csp %s", cspName)
 	}
 	_, err = c.KubeClientset.AppsV1().Deployments(openebsNamespace).
 		Patch(


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR handles the scenario where the csp deployments are scaled up by mistake. The path to the lock file is different for csp and cspi deployments which leads to multiple simultaneous imports. Patching the `tmp` path while scaling down the csp deployment fixes this problem.

csp Volumes
```yaml
volumes:
    - hostPath:
        path: /dev
        type: Directory
        name: device
    - hostPath:
        path: /run/udev
        type: Directory
        name: udev
    - hostPath:
        path: /var/openebs/sparse/shared-cstor-pool
        type: DirectoryOrCreate
        name: tmp
    - hostPath:
        path: /var/openebs/sparse
        type: DirectoryOrCreate
        name: sparse
    - hostPath:
        path: /var/openebs/cstor-pool/cstor-pool
        type: DirectoryOrCreate
        name: storagepath
    - emptyDir: {}
        name: sockfile

```

cspi Volumes
```yaml
volumes:
    - hostPath:
        path: /dev
        type: Directory
        name: device
    - hostPath:
        path: /run/udev
        type: Directory
        name: udev
    - hostPath:
        path: /var/openebs/cstor-pool/cstor-pool
        type: DirectoryOrCreate
        name: tmp
    - hostPath:
        path: /var/openebs/sparse
        type: DirectoryOrCreate
        name: sparse
    - hostPath:
        path: /var/openebs/cstor-pool/cstor-pool
        type: DirectoryOrCreate
        name: storagepath
    - emptyDir: {}
        name: sockfile

```

**Which issue(s) this PR fixes**:
Fixes #82 


**Special notes for your reviewer**:

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated