### PR TITLE
feat(upgrade): remove the -amd64 suffix from images

### DIFF
--- a/pkg/upgrade/upgrader/cstor_cspi.go
+++ b/pkg/upgrade/upgrader/cstor_cspi.go
@@ -265,6 +265,8 @@ func transformCSPIDeploy(d *appsv1.Deployment, res *ResourcePatch) error {
 		if err != nil {
 			return err
 		}
+		// remove the -amd64 prefix from the image
+		url = removeSuffixFromEnd(url, "-amd64")
 		d.Spec.Template.Spec.Containers[i].Image = url + ":" + tag
 	}
 	d.Labels["openebs.io/version"] = res.To

--- a/pkg/upgrade/upgrader/cstor_volume.go
+++ b/pkg/upgrade/upgrader/cstor_volume.go
@@ -210,6 +210,8 @@ func (obj *CStorVolumePatch) transformCVDeploy(d *appsv1.Deployment, res *Resour
 		if err != nil {
 			return err
 		}
+		// remove the -amd64 prefix from the image
+		url = removeSuffixFromEnd(url, "-amd64")
 		d.Spec.Template.Spec.Containers[i].Image = url + ":" + tag
 	}
 	pvObj, err := obj.KubeClientset.CoreV1().PersistentVolumes().

--- a/pkg/upgrade/upgrader/helper.go
+++ b/pkg/upgrade/upgrader/helper.go
@@ -90,9 +90,14 @@ func isOperatorUpgraded(componentName string, namespace string,
 // Remove the suffix only if it is present
 // at the end of the string
 func removeSuffixFromEnd(str, suffix string) string {
-	i := strings.LastIndex(str, suffix)
-	if i > -1 && i == len(str)-len(suffix) {
-		str = str[:i]
+	slice := strings.Split(str, "/")
+	// if the image is from openebs registry and has a suffix -amd64
+	// then only perform the operation
+	if slice[len(slice)-2] == "openebs" && strings.HasSuffix(slice[len(slice)-1], "-amd64") {
+		i := strings.LastIndex(str, suffix)
+		if i > -1 && i == len(str)-len(suffix) {
+			str = str[:i]
+		}
 	}
 	return str
 }

--- a/pkg/upgrade/upgrader/helper.go
+++ b/pkg/upgrade/upgrader/helper.go
@@ -86,3 +86,13 @@ func isOperatorUpgraded(componentName string, namespace string,
 	}
 	return nil
 }
+
+// Remove the suffix only if it is present
+// at the end of the string
+func removeSuffixFromEnd(str, suffix string) string {
+	i := strings.LastIndex(str, suffix)
+	if i > -1 && i == len(str)-len(suffix) {
+		str = str[:i]
+	}
+	return str
+}

--- a/pkg/upgrade/upgrader/helper_test.go
+++ b/pkg/upgrade/upgrader/helper_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrader
+
+import "testing"
+
+func Test_removeSuffixFromEnd(t *testing.T) {
+	type args struct {
+		str    string
+		suffix string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "with suffix",
+			args: args{
+				str:    "openebs/cstor-operator-amd64",
+				suffix: "-amd64",
+			},
+			want: "openebs/cstor-operator",
+		},
+		{
+			name: "without suffix",
+			args: args{
+				str:    "openebs/cstor-operator",
+				suffix: "-amd64",
+			},
+			want: "openebs/cstor-operator",
+		},
+		{
+			name: "airgap with suffix",
+			args: args{
+				str:    "air-gap-having-amd64/openebs/cstor-operator-amd64",
+				suffix: "-amd64",
+			},
+			want: "air-gap-having-amd64/openebs/cstor-operator",
+		},
+		{
+			name: "airgap without suffix",
+			args: args{
+				str:    "air-gap-having-amd64/openebs/cstor-operator",
+				suffix: "-amd64",
+			},
+			want: "air-gap-having-amd64/openebs/cstor-operator",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeSuffixFromEnd(tt.args.str, tt.args.suffix); got != tt.want {
+				t.Errorf("removeSuffix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/upgrade/upgrader/helper_test.go
+++ b/pkg/upgrade/upgrader/helper_test.go
@@ -60,6 +60,22 @@ func Test_removeSuffixFromEnd(t *testing.T) {
 			},
 			want: "air-gap-having-amd64/openebs/cstor-operator",
 		},
+		{
+			name: "custom repository with suffix",
+			args: args{
+				str:    "air-gap-having-amd64/custom/cstor-operator-amd64",
+				suffix: "-amd64",
+			},
+			want: "air-gap-having-amd64/custom/cstor-operator-amd64",
+		},
+		{
+			name: "custom repository without suffix",
+			args: args{
+				str:    "air-gap-having-amd64/custom/cstor-operator",
+				suffix: "-amd64",
+			},
+			want: "air-gap-having-amd64/custom/cstor-operator",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR adds the code to remove -amd64 suffix from the older cspc and cstor volume deployments which is no longer available with the multi-arch builds.

**Which issue(s) this PR fixes**:
Fixes #84 


**Special notes for your reviewer**:

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated