### PR TITLE
refact(migrate): improve logs and docs about multiple cstorvolume apis

### DIFF
--- a/changelogs/unreleased/96-shubham14bajpai
+++ b/changelogs/unreleased/96-shubham14bajpai
@@ -1,0 +1,1 @@
+refact(migrate): improve logs and docs about multiple cstorvolume apis

--- a/cmd/migrate/executor/cstor_pool.go
+++ b/cmd/migrate/executor/cstor_pool.go
@@ -87,6 +87,8 @@ func (m *MigrateOptions) RunCStorSPCMigrate() error {
 		return errors.Errorf("Failed to migrate cStor SPC : %s", m.spcName)
 	}
 	klog.Infof("Successfully migrated spc %s to cspc", m.spcName)
-
+	klog.Infof("Make sure to migrate the associated PVCs, " +
+		"to find the old PVCs use `kubectl get cstorvolume.openebs.io -n <openebs-namespace>`, " +
+		"and to get the migrated PVCs use `kubectl get cstorvolume.cstor.openebs.io -n <openebs-namespace>`")
 	return nil
 }

--- a/cmd/migrate/executor/cstor_pool.go
+++ b/cmd/migrate/executor/cstor_pool.go
@@ -87,8 +87,10 @@ func (m *MigrateOptions) RunCStorSPCMigrate() error {
 		return errors.Errorf("Failed to migrate cStor SPC : %s", m.spcName)
 	}
 	klog.Infof("Successfully migrated spc %s to cspc", m.spcName)
-	klog.Infof("Make sure to migrate the associated PVCs, " +
-		"to find the old PVCs use `kubectl get cstorvolume.openebs.io -n <openebs-namespace>`, " +
-		"and to get the migrated PVCs use `kubectl get cstorvolume.cstor.openebs.io -n <openebs-namespace>`")
+
+	klog.Infof("Make sure to migrate the associated PVs, "+
+		"to list CStorVolumes for the PVs which are pending migration use `kubectl get cstorvolume.openebs.io -n %s -l openebs.io/storage-pool-claim=%s`, "+
+		"and to list CStorVolumes for the migrated/CSI PVs use `kubectl get cstorvolume.cstor.openebs.io -n %s`",
+		m.openebsNamespace, m.spcName, m.openebsNamespace)
 	return nil
 }

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -127,7 +127,7 @@ I0520 10:01:25.798889       1 pool.go:80] Successfully migrated spc sparse-claim
 
 **<span style="color: red;">Note: In case the job fails for any reason please do not scale up the old CSP deployments. It can lead to data corruption.</span>**
 
-Make sure to migrate the associated PVCs, to find the old PVCs use `kubectl get cstorvolume.openebs.io -n <openebs-namespace>` and to get the migrated PVCs use `kubectl get cstorvolume.cstor.openebs.io -n <openebs-namespace>`
+Make sure to migrate the associated PVs, to list CStorVolumes for the PVs which are pending for migration use `kubectl get cstorvolume.openebs.io -n <openebs-namespace> -l openebs.io/storage-pool-claim=<spc-name>` and to list CStorVolumes for the migrated/CSI PVs use `kubectl get cstorvolume.cstor.openebs.io -n <openebs-namespace>`
 
 ## cStor External Provisioned volumes to cStor CSI volumes
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -127,6 +127,7 @@ I0520 10:01:25.798889       1 pool.go:80] Successfully migrated spc sparse-claim
 
 **<span style="color: red;">Note: In case the job fails for any reason please do not scale up the old CSP deployments. It can lead to data corruption.</span>**
 
+Make sure to migrate the associated PVCs, to find the old PVCs use `kubectl get cstorvolume.openebs.io -n <openebs-namespace>` and to get the migrated PVCs use `kubectl get cstorvolume.cstor.openebs.io -n <openebs-namespace>`
 
 ## cStor External Provisioned volumes to cStor CSI volumes
 

--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -25,6 +25,7 @@ var (
 		"1.10.0": true, "1.11.0": true, "1.12.0": true,
 		"2.0.0": true, "2.1.0": true, "2.2.0": true, "2.3.0": true,
 		"2.4.0": true, "2.4.1": true, "2.5.0": true, "2.6.0": true,
+		"2.7.0": true,
 	}
 	validDesiredVersion = strings.Split(GetVersion(), "-")[0]
 )


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR adds logs and documentation about the multiple cstorvolume apis present in the cluster during migration. When the pools are migrated and volumes are still pending for migration there may be some volumes in the newer volumes in `cstorvolume.cstor.openebs.io` while some will still be in older api `cstorvolume.openebs.io`. The changes informs the user of such situations.

This PR also bumps the version matrix for 2.7.0

Ref: https://kubernetes.slack.com/archives/CUAKPFU78/p1614522935143200?thread_ts=1614470259.132700&cid=CUAKPFU78

**Which issue(s) this PR fixes**:
Fixes #<issue number>


**Special notes for your reviewer**:

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated