### PR TITLE
chore(github-action): Refine GitHub Actions criteria for builds, pull requests and release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,11 @@
 # limitations under the License.
 name: build
 
-on: ['push']
+on:
+  push:
+    paths-ignore:
+    - 'docs/**'
+    - 'changelogs/**'
 
 jobs:
   lint:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,22 @@
 name: build
 
 on:
+  create:
   push:
+    branches:
+      - 'master'
+      - 'v*'
     paths-ignore:
-    - 'docs/**'
-    - 'changelogs/**'
+      - '*.md'
+      - 'changelogs/**'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'MAINTAINERS'
 
 jobs:
   lint:
+    # to ignore builds on release
+    if: ${{ (github.event.ref_type != 'tag') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -206,6 +215,8 @@ jobs:
             BRANCH=${{ env.BRANCH }}
 
   unit-tests:
+    # to ignore builds on release
+    if: ${{ (github.event.ref_type != 'tag') }}
     name: unit tests 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,13 +16,16 @@ name: ci
 
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'changelogs/**'
     branches:
       # on pull requests to master and release branches
-      - master
+      - 'master'
       - 'v*'
+    paths-ignore:
+      - '*.md'
+      - 'changelogs/**'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'MAINTAINERS'
 
 jobs:
   lint:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,6 +16,9 @@ name: ci
 
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'changelogs/**'
     branches:
       # on pull requests to master and release branches
       - master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@
 name: release
 
 on:
-  create:
-    tags:
-      - 'v*'
+  release:
+    types:
+      - 'created'
 
 jobs:
   upgrade:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ on:
   release:
     types:
       - 'created'
+    tags:
+      - 'v*'
 
 jobs:
   upgrade:


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

The build.yml and pull_request.yml workflows will ignore pushes made to `docs/` and `changelogs/` directories, all `.md` files, LICENSE and MAINTAINERS files.

Added criteria to ignore build workflows on release. 