### PR TITLE
fix(logs): remove label for listing cstorvolumes

### DIFF
--- a/cmd/migrate/executor/cstor_pool.go
+++ b/cmd/migrate/executor/cstor_pool.go
@@ -89,8 +89,8 @@ func (m *MigrateOptions) RunCStorSPCMigrate() error {
 	klog.Infof("Successfully migrated spc %s to cspc", m.spcName)
 
 	klog.Infof("Make sure to migrate the associated PVs, "+
-		"to list CStorVolumes for the PVs which are pending migration use `kubectl get cstorvolume.openebs.io -n %s -l openebs.io/storage-pool-claim=%s`, "+
+		"to list CStorVolumes for the PVs which are pending migration use `kubectl get cstorvolume.openebs.io -n %s`, "+
 		"and to list CStorVolumes for the migrated/CSI PVs use `kubectl get cstorvolume.cstor.openebs.io -n %s`",
-		m.openebsNamespace, m.spcName, m.openebsNamespace)
+		m.openebsNamespace, m.openebsNamespace)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:

This PR fixes the logs for migration as the cstorvolume don't have the label mentioned in the log

```
$ kubectl get cstorvolumes.openebs.io -n openebs --show-labels
NAME                                       STATUS   AGE   CAPACITY   LABELS
pvc-7019dcf7-cd9f-48b2-8846-df89c830ebea   Init     26m   2G         openebs.io/cas-template-name=cstor-volume-create-default-2.9.0,openebs.io/persistent-volume=pvc-7019dcf7-cd9f-48b2-8846-df89c830ebea,openebs.io/version=2.9.0
```
**Which issue(s) this PR fixes**:
Fixes #<issue number>


**Special notes for your reviewer**:

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated