### PR TITLE
fix(upgrade): update cstor serviceAccount in cspi and target deployments

### DIFF
--- a/ci/upgrade/cstor/cstor-operator.tmp.yaml
+++ b/ci/upgrade/cstor/cstor-operator.tmp.yaml
@@ -37,7 +37,7 @@ spec:
         openebs.io/component-name: cspc-operator
         openebs.io/version: testversion
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: openebs-cstor-operator
       containers:
       - name: cspc-operator
         imagePullPolicy: IfNotPresent
@@ -99,7 +99,7 @@ spec:
         openebs.io/component-name: cvc-operator
         openebs.io/version: testversion
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: openebs-cstor-operator
       containers:
       - name: cvc-operator
         imagePullPolicy: IfNotPresent
@@ -178,7 +178,7 @@ spec:
         openebs.io/component-name: cstor-admission-webhook
         openebs.io/version: testversion
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: openebs-cstor-operator
       containers:
         - name: admission-webhook
           image: imageorg/cstor-webhook:testimage

--- a/ci/upgrade/cstor/ndm-operator.yaml
+++ b/ci/upgrade/cstor/ndm-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2020 The OpenEBS Authors
+# Copyright © 2020-2021 The OpenEBS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ metadata:
   labels:
     name: openebs-ndm
     openebs.io/component-name: ndm
-    openebs.io/version: 1.10.0
+    openebs.io/version: 2.0.0
 spec:
   selector:
     matchLabels:
@@ -73,7 +73,7 @@ spec:
       labels:
         name: openebs-ndm
         openebs.io/component-name: ndm
-        openebs.io/version: 1.10.0
+        openebs.io/version: 2.0.0
     spec:
       # By default the node-disk-manager will be run on all kubernetes nodes
       # If you would like to limit this to only some nodes, say the nodes
@@ -86,14 +86,19 @@ spec:
       #  "openebs.io/nodegroup": "storage-node"
       serviceAccountName: openebs-maya-operator
       hostNetwork: true
+      # host PID is used to check status of iSCSI Service when the NDM
+      # API service is enabled
+      #hostPID: true
       containers:
       - name: node-disk-manager
-        image: quay.io/openebs/node-disk-manager-amd64:0.5.0
+        image: openebs/node-disk-manager:0.8.2
         args:
           - -v=4
         # The feature-gate is used to enable the new UUID algorithm.
-        # This is a feature currently in Alpha state
-        #  - --feature-gates="GPTBasedUUID"
+          - --feature-gates="GPTBasedUUID"
+        # The feature gate is used to start the gRPC API service. The gRPC server
+        # starts at 9115 port by default. This feature is currently in Alpha state
+        # - --feature-gates="APIService"
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -107,6 +112,8 @@ spec:
         - name: procmount
           mountPath: /host/proc
           readOnly: true
+        - name: devmount
+          mountPath: /dev
         - name: basepath
           mountPath: /var/openebs/ndm
         - name: sparsepath
@@ -154,6 +161,12 @@ spec:
         hostPath:
           path: /proc
           type: Directory
+      - name: devmount
+      # the /dev directory is mounted so that we have access to the devices that
+      # are connected at runtime of the pod.
+        hostPath:
+          path: /dev
+          type: Directory
       - name: basepath
         hostPath:
           path: /var/openebs/ndm
@@ -170,7 +183,7 @@ metadata:
   labels:
     name: openebs-ndm-operator
     openebs.io/component-name: ndm-operator
-    openebs.io/version: 1.10.0
+    openebs.io/version: 2.0.0
 spec:
   selector:
     matchLabels:
@@ -184,12 +197,12 @@ spec:
       labels:
         name: openebs-ndm-operator
         openebs.io/component-name: ndm-operator
-        openebs.io/version: 1.10.0
+        openebs.io/version: 2.0.0
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: node-disk-operator
-          image: quay.io/openebs/node-disk-operator-amd64:0.5.0
+          image: openebs/node-disk-operator:0.8.2
           imagePullPolicy: IfNotPresent
           readinessProbe:
             exec:
@@ -216,7 +229,7 @@ spec:
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE
-              value: "quay.io/openebs/linux-utils:1.10.0"
+              value: "openebs/linux-utils:2.0.0"
             # OPENEBS_IO_INSTALL_CRD environment variable is used to enable/disable CRD installation
             # from NDM operator. By default the CRDs will be installed
             #- name: OPENEBS_IO_INSTALL_CRD
@@ -232,25 +245,3 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 60
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: upgradetasks.openebs.io
-spec:
-  # group name to use for REST API: /apis/<group>/<version>
-  group: openebs.io
-  # version name to use for REST API: /apis/<group>/<version>
-  version: v1alpha1
-  # either Namespaced or Cluster
-  scope: Namespaced
-  names:
-    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
-    plural: upgradetasks
-    # singular name to be used as an alias on the CLI and for display
-    singular: upgradetask
-    # kind is normally the CamelCased singular type. Your resource manifests use this.
-    kind: UpgradeTask
-    # shortNames allow shorter string to match your resource on the CLI
-    shortNames:
-    - utask

--- a/ci/upgrade/cstor/pool.tmp.yaml
+++ b/ci/upgrade/cstor/pool.tmp.yaml
@@ -36,14 +36,14 @@ spec:
       # VERIFY the value of serviceAccountName is pointing to service account
       # created within openebs namespace. Use the non-default account.
       # by running `kubectl get sa -n <openebs-namespace>`
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: openebs-cstor-operator
       containers:
       - name:  upgrade
         args:
         - "cstor-cspc"
 
         # --from-version is the current version of the pool
-        - "--from-version=1.10.0"
+        - "--from-version=2.0.0"
 
         # --to-version is the version desired upgrade version
         - "--to-version=testversion"

--- a/ci/upgrade/cstor/sanity.sh
+++ b/ci/upgrade/cstor/sanity.sh
@@ -66,6 +66,7 @@ if [ $? != 0 ]; then
   kubectl logs -l job-name=upgrade-pool -n openebs
   kubectl logs -l job-name=upgrade-volume -n openebs
   kubectl describe pods -n openebs
+  kubectl describe deploy -n openebs
   exit 1
 fi
 

--- a/ci/upgrade/cstor/setup.sh
+++ b/ci/upgrade/cstor/setup.sh
@@ -17,13 +17,12 @@
 
 set -ex
 
-echo "Install cstor-operators in 1.10.0"
+echo "Install cstor-operators in 2.0.0"
 
 kubectl create ns openebs
 
-kubectl apply -f ./ci/upgrade/cstor/ndm-operator.yaml \
- -f https://raw.githubusercontent.com/openebs/charts/master/archive/1.10.x/csi-operator-1.10.0-ubuntu-18.04.yaml \
- -f https://raw.githubusercontent.com/openebs/charts/master/archive/1.10.x/cstor-operator-1.10.0.yaml 
+kubectl apply -f https://raw.githubusercontent.com/openebs/charts/gh-pages/2.0.0/cstor-operator.yaml \
+    -f ./ci/upgrade/cstor/ndm-operator.yaml 
 sleep 100
 
 echo "Wait for cspc-operator to start"
@@ -43,7 +42,11 @@ echo "Upgrade control plane to latest version"
 
 sed "s|testimage|$TEST_IMAGE_TAG|g" ./ci/upgrade/cstor/cstor-operator.tmp.yaml | sed "s|testversion|$TEST_VERSION|g" | sed "s|imageorg|$IMAGE_ORG|g" > ./ci/upgrade/cstor/cstor-operator.yaml
 
-kubectl apply -f https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/csi-operator.yaml \
+kubectl delete csidriver cstor.csi.openebs.io
+
+kubectl apply -f https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/crds/all_cstor_crds.yaml \
+ -f https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/rbac.yaml \
+ -f https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/csi-operator.yaml \
  -f ./ci/upgrade/cstor/cstor-operator.yaml -f https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/ndm-operator.yaml
 sleep 10
 kubectl wait --for=condition=available --timeout=300s deployment/cspc-operator -n openebs

--- a/ci/upgrade/cstor/volume.tmp.yaml
+++ b/ci/upgrade/cstor/volume.tmp.yaml
@@ -36,14 +36,14 @@ spec:
       # VERIFY the value of serviceAccountName is pointing to service account
       # created within openebs namespace. Use the non-default account.
       # by running `kubectl get sa -n <openebs-namespace>`
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: openebs-cstor-operator
       containers:
       - name:  upgrade
         args:
         - "cstor-volume"
 
         # --from-version is the current version of the volume
-        - "--from-version=1.10.0"
+        - "--from-version=2.0.0"
 
         # --to-version is the version desired upgrade version
         - "--to-version=testversion"

--- a/pkg/upgrade/upgrader/cstor_cspi.go
+++ b/pkg/upgrade/upgrader/cstor_cspi.go
@@ -271,6 +271,7 @@ func transformCSPIDeploy(d *appsv1.Deployment, res *ResourcePatch) error {
 		d.Spec.Template.Spec.Containers[i].Image = url + ":" + tag
 	}
 	d.Labels["openebs.io/version"] = res.To
+	d.Spec.Template.Labels["openebs.io/version"] = res.To
 	d.Spec.Template.Spec.ServiceAccountName = cstorOperatorServiceAccount
 	return nil
 }

--- a/pkg/upgrade/upgrader/cstor_cspi.go
+++ b/pkg/upgrade/upgrader/cstor_cspi.go
@@ -241,13 +241,13 @@ func (obj *CSPIPatch) Init() (string, error) {
 	return "", nil
 }
 
-func getCSPIDeployPatchData(obobj *CSPIPatch) error {
-	newDeploy := obobj.Deploy.Object.DeepCopy()
-	err := transformCSPIDeploy(newDeploy, obobj.ResourcePatch)
+func getCSPIDeployPatchData(obj *CSPIPatch) error {
+	newDeploy := obj.Deploy.Object.DeepCopy()
+	err := transformCSPIDeploy(newDeploy, obj.ResourcePatch)
 	if err != nil {
 		return err
 	}
-	obobj.Deploy.Data, err = GetPatchData(obobj.Deploy.Object, newDeploy)
+	obj.Deploy.Data, err = GetPatchData(obj.Deploy.Object, newDeploy)
 	return err
 }
 
@@ -271,7 +271,7 @@ func transformCSPIDeploy(d *appsv1.Deployment, res *ResourcePatch) error {
 		d.Spec.Template.Spec.Containers[i].Image = url + ":" + tag
 	}
 	d.Labels["openebs.io/version"] = res.To
-	d.Spec.Template.Labels["openebs.io/version"] = res.To
+	d.Spec.Template.Spec.ServiceAccountName = cstorOperatorServiceAccount
 	return nil
 }
 

--- a/pkg/upgrade/upgrader/cstor_volume.go
+++ b/pkg/upgrade/upgrader/cstor_volume.go
@@ -125,7 +125,11 @@ func (obj *CStorVolumePatch) Init() (string, error) {
 	if err != nil {
 		return "failed to get target svc for volume" + obj.Name, err
 	}
-	err = obj.getCVCPatchData()
+	return "", nil
+}
+
+func (obj *CStorVolumePatch) GetVolumePatches() (string, error) {
+	err := obj.getCVCPatchData()
 	if err != nil {
 		return "failed to create CVC patch for volume" + obj.Name, err
 	}
@@ -301,6 +305,16 @@ func (obj *CStorVolumePatch) Upgrade() error {
 		return errors.Wrap(err, msg)
 	}
 	msg, err = obj.PreUpgrade()
+	if err != nil {
+		statusObj.Message = msg
+		statusObj.Reason = err.Error()
+		obj.Utask, uerr = updateUpgradeDetailedStatus(obj.Utask, statusObj, obj.OpenebsNamespace, obj.Client)
+		if uerr != nil && isUpgradeTaskJob {
+			return uerr
+		}
+		return errors.Wrap(err, msg)
+	}
+	msg, err = obj.GetVolumePatches()
 	if err != nil {
 		statusObj.Message = msg
 		statusObj.Reason = err.Error()

--- a/pkg/upgrade/upgrader/cstor_volume.go
+++ b/pkg/upgrade/upgrader/cstor_volume.go
@@ -224,6 +224,7 @@ func (obj *CStorVolumePatch) transformCVDeploy(d *appsv1.Deployment, res *Resour
 	d.Spec.Template.Labels["openebs.io/persistent-volume-claim"] = pvObj.Spec.ClaimRef.Name
 	d.Labels["openebs.io/version"] = res.To
 	d.Spec.Template.Labels["openebs.io/version"] = res.To
+	d.Spec.Template.Spec.ServiceAccountName = cstorOperatorServiceAccount
 	return nil
 }
 

--- a/pkg/upgrade/upgrader/helper.go
+++ b/pkg/upgrade/upgrader/helper.go
@@ -28,6 +28,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+var (
+	cstorOperatorServiceAccount = "openebs-cstor-operator"
+)
+
 func getImageURL(url, prefix string) (string, error) {
 	lastIndex := strings.LastIndex(url, ":")
 	if lastIndex == -1 {
@@ -84,6 +88,9 @@ func isOperatorUpgraded(componentName string, namespace string,
 			return fmt.Errorf("%s is in %s version, please upgrade it to %s version",
 				componentName, pod.Labels["openebs.io/version"], toVersion)
 		}
+	}
+	if componentName == "cspc-operator" || componentName == "cvc-operator" {
+		cstorOperatorServiceAccount = operatorPods.Items[0].Spec.ServiceAccountName
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR fixes the service account change issue. In the operator yamls before 2.8.0 the service account used was `openebs-maya-operator` and the clusterrole/clusterrolebinding were named` openebs-cstor-operator`. From 2.8.0 the service account was renamed to `openebs-cstor-operator` and the clusterrole/clusterrolebinding are updated with the . Now the older deployments have the old service account but the clusterrole/clusterrolebinding point to the new service account. Patching the deployments with the new service account name fixes the problem.

**Which issue(s) this PR fixes**:
Fixes #<issue number>


**Special notes for your reviewer**:

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated