### PR TITLE
chore(doc): add note about day-2-operations when control plane alone is upgraded

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Below are the steps for upgrading the OpenEBS reources:
 
 **Note:** 
  - If current version of ndm-operator is 1.12.0 or below and using virtual disks as blockdevices for provisioning cStor pool please refer this [doc](https://github.com/openebs/upgrade/blob/master/docs/virtual-disk-troubleshoot.md) before proceeding.
+ - After upgrading the cStor or Jiva control plane, you have to upgrade Jiva/cStor pools and volumes to the latest control plane version as early as possible. While Jiva/cStor pools and volumes will continue to work, the management operations like **_Volume Expansion, Volume Migration, Ongoing Pool/Volume Provisioning, cStor Pool Scaleup/Scaledown, cStor VolumeReplica Scaling, cStor Pool Expansion_** will **not be supported** when the control plane and the pools, volumes are in different versions.
 
 ## [Migrating cStor pools and volumes from SPC to CSPC](https://github.com/openebs/upgrade/blob/master/docs/migration.md)
 Below are the steps for migrating the OpenEBS cStor custom reources:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Below are the steps for upgrading the OpenEBS reources:
 
 **Note:** 
  - If current version of ndm-operator is 1.12.0 or below and using virtual disks as blockdevices for provisioning cStor pool please refer this [doc](https://github.com/openebs/upgrade/blob/master/docs/virtual-disk-troubleshoot.md) before proceeding.
- - After upgrading the cStor or Jiva control plane, you have to upgrade Jiva/cStor pools and volumes to the latest control plane version as early as possible. While Jiva/cStor pools and volumes will continue to work, the management operations like **_Volume Expansion, Volume Migration, Ongoing Pool/Volume Provisioning, cStor Pool Scaleup/Scaledown, cStor VolumeReplica Scaling, cStor Pool Expansion_** will **not be supported** when the control plane and the pools, volumes are in different versions.
+ - After upgrading the cStor or Jiva control plane, you have to upgrade Jiva/cStor pools and volumes to the latest control plane version as early as possible. While Jiva/cStor pools and volumes will continue to work, the management operations like **_Ongoing Pool/Volume Provisioning, Volume Expansion, Volume Replica Migration, cStor Pool Scaleup/Scaledown, cStor VolumeReplica Scaling, cStor Pool Expansion_** will **not be supported** due to difference in control plane and pools/volumes version.
 
 ## [Migrating cStor pools and volumes from SPC to CSPC](https://github.com/openebs/upgrade/blob/master/docs/migration.md)
 Below are the steps for migrating the OpenEBS cStor custom reources:

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -19,7 +19,7 @@ Before upgrading the pools make sure the following prerequisites are taken care 
  - Upgrade the control plane components by applying the desired version of cstor-operator from the [charts](https://github.com/openebs/charts/tree/gh-pages). 
  
  **Note:**
- 1. Day-2-operations of cStor pools & cStor volumes doesn't support when control plane alone is upgraded.
+ 1. After upgrading the control plane, you have to upgrade cStor pools and volumes to the latest control plane version as early as possible. While cStor pools & volumes will continue to work, the management operations like **_Volume Expansion, Volume Migration, Ongoing Pool/Volume Provisioning, cStor Pool Scaleup/Scaledown, cStor VolumeReplica Scaling, cStor Pool Expansion_** will **not be supported** when the control plane and the pools, volumes are in different versions.
  2. If upgrading the control plane from 2.4.0 or the previous versions to the latest version please clean up the CSIDriver CR before applying the operator using the below command.
     ```sh
     kubectl delete csidriver cstor.csi.openebs.io
@@ -278,7 +278,7 @@ These instructions will guide you through the process of upgrading jiva CSI volu
 Before upgrading the volumes make sure the following prerequisites are taken care of:
 
  - Upgrade the jiva operator to desired version by applying the jiva-operator from the [charts](https://github.com/openebs/charts/tree/gh-pages).
-
+ - After upgrading the Jiva control plane, you have to upgrade Jiva volumes to the latest control plane version as early as possible. While Jiva volumes will continue to work, the management operations like **_Volume Expansion, Volume Migration, Ongoing Volume Provisioning_** will **not be supported** when the control plane and the pools, volumes are in different versions.
  - Check for the `REMOUNT` env in `openebs-jiva-csi-node` daemonset, if disabled then scaling down the application before upgrading the volume is recommended to avoid any read-only issues.
 
 ### Running the upgrade job

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -18,24 +18,28 @@ Before upgrading the pools make sure the following prerequisites are taken care 
 
  - Upgrade the control plane components by applying the desired version of cstor-operator from the [charts](https://github.com/openebs/charts/tree/gh-pages). 
  
- **Note:** If upgrading the control plane from 2.4.0 or the previous versions to the latest version please clean up the CSIDriver CR before applying the operator using the below command.
-  ```sh
-  kubectl delete csidriver cstor.csi.openebs.io
-  ```
+ **Note:**
+ 1. Day-2-operations of cStor pools & cStor volumes doesn't support when control plane alone is upgraded.
+ 2. If upgrading the control plane from 2.4.0 or the previous versions to the latest version please clean up the CSIDriver CR before applying the operator using the below command.
+    ```sh
+    kubectl delete csidriver cstor.csi.openebs.io
+    ```
 
- You can verify the current version of the control plane using the command:
+    You can verify the current version of the control plane using the command:
     
-    $ kubectl -n openebs get pods -l openebs.io/version=<version>
+     kubectl -n openebs get pods -l openebs.io/version=<version>
      
- where `<version>` is the desired version.
+     where `<version>` is the desired version.
     
- For example if desired version is `2.12.0` the output should look like:
+    For example if desired version is `2.12.0` the output should look like:
     
-    $ kubectl -n openebs get pods -l openebs.io/version=2.12.0
-    NAME                                              READY   STATUS    RESTARTS   AGE
-    cspc-operator-7744bfb75-fj2w8                     1/1     Running   0          6m11s
-    cvc-operator-5c6456df79-jpl5c                     1/1     Running   0          6m11s
-    openebs-cstor-admission-server-845d78b97d-sgcnh   1/1     Running   0          6m10s
+    ```sh
+     $ kubectl -n openebs get pods -l openebs.io/version=2.12.0
+     NAME                                              READY   STATUS    RESTARTS   AGE
+     cspc-operator-7744bfb75-fj2w8                     1/1     Running   0          6m11s
+     cvc-operator-5c6456df79-jpl5c                     1/1     Running   0          6m11s
+     openebs-cstor-admission-server-845d78b97d-sgcnh   1/1     Running   0          6m10s
+     ```
     
 
 ### Running the upgrade job

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -19,7 +19,7 @@ Before upgrading the pools make sure the following prerequisites are taken care 
  - Upgrade the control plane components by applying the desired version of cstor-operator from the [charts](https://github.com/openebs/charts/tree/gh-pages). 
  
  **Note:**
- 1. After upgrading the control plane, you have to upgrade cStor pools and volumes to the latest control plane version as early as possible. While cStor pools & volumes will continue to work, the management operations like **_Volume Expansion, Volume Migration, Ongoing Pool/Volume Provisioning, cStor Pool Scaleup/Scaledown, cStor VolumeReplica Scaling, cStor Pool Expansion_** will **not be supported** when the control plane and the pools, volumes are in different versions.
+ 1. After upgrading the control plane, you have to upgrade cStor pools and volumes to the latest control plane version as early as possible. While cStor pools & volumes will continue to work, the management operations like **_Ongoing Pool/Volume Provisioning, Volume Expansion, Volume Replica Migration, cStor Pool Scaleup/Scaledown, cStor VolumeReplica Scaling, cStor Pool Expansion_** will **not be supported** due to difference in control plane and pools/volumes version.
  2. If upgrading the control plane from 2.4.0 or the previous versions to the latest version please clean up the CSIDriver CR before applying the operator using the below command.
     ```sh
     kubectl delete csidriver cstor.csi.openebs.io
@@ -278,7 +278,7 @@ These instructions will guide you through the process of upgrading jiva CSI volu
 Before upgrading the volumes make sure the following prerequisites are taken care of:
 
  - Upgrade the jiva operator to desired version by applying the jiva-operator from the [charts](https://github.com/openebs/charts/tree/gh-pages).
- - After upgrading the Jiva control plane, you have to upgrade Jiva volumes to the latest control plane version as early as possible. While Jiva volumes will continue to work, the management operations like **_Volume Expansion, Volume Migration, Ongoing Volume Provisioning_** will **not be supported** when the control plane and the pools, volumes are in different versions.
+ - After upgrading the Jiva control plane, you have to upgrade Jiva volumes to the latest control plane version as early as possible. While Jiva volumes will continue to work, the management operations like **_Ongoing Pool/Volume Provisioning, Volume Expansion, Volume Replica Migration, Volume Replica Scaling** will **not be supported** due to difference in control plane and pools/volumes version.
  - Check for the `REMOUNT` env in `openebs-jiva-csi-node` daemonset, if disabled then scaling down the application before upgrading the volume is recommended to avoid any read-only issues.
 
 ### Running the upgrade job


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Adds a note under the prerequisites section **informing
Day-2-Operations doesn't support** when the control plane
and pools/volumes in different version.

**Which issue(s) this PR fixes**:
Fixes #<issue number>


**Special notes for your reviewer**:
No

**Checklist**
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
