### PR TITLE
doc: change in default service account name

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -71,7 +71,7 @@ spec:
       # VERIFY the value of serviceAccountName is pointing to service account
       # created within openebs namespace. Use the non-default account.
       # by running `kubectl get sa -n <openebs-namespace>`
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: openebs-cstor-operator
       containers:
       - name:  upgrade
         args:


### PR DESCRIPTION

The default service account name is changed at least in the latest cspc-operator. 
So considering it, it may require this change for convenience of the users following this doc.
Not certain, that this change is required.

**Special notes for your reviewer**:

**Checklist**
- [x] PR messages has document related information
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has breaking changes related information
- [ ] PR messages has upgrade related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] Tests updated