### PR TITLE
chore(version): add 3.1.0 to upgrade matrix

### DIFF
--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -27,7 +27,7 @@ var (
 		"2.4.0": true, "2.4.1": true, "2.5.0": true, "2.6.0": true,
 		"2.7.0": true, "2.8.0": true, "2.9.0": true, "2.10.0": true,
 		"2.10.1": true, "2.11.0": true, "2.12.0": true, "2.12.1": true,
-		"2.12.2": true, "3.0.0": true,
+		"2.12.2": true, "3.0.0": true, "3.1.0": true,
 	}
 	validDesiredVersion = strings.Split(GetVersion(), "-")[0]
 )


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide for detailed contributing guidelines.
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR adds 3.1.0 version as supported version to
upgrade to latest OpenEBS versions.



Signed-off-by: Sai <Sai.Chaithanya@datacore.com>